### PR TITLE
Fix model compilation.

### DIFF
--- a/neuralhydrology/modelzoo/__init__.py
+++ b/neuralhydrology/modelzoo/__init__.py
@@ -23,7 +23,6 @@ SINGLE_FREQ_MODELS = ["handoff_forecast_lstm"]
 AUTOREGRESSIVE_MODELS = []
 
 
-torch.compile(mode="max-autotune")
 def get_model(cfg: Config) -> nn.Module:
     """Get model object, depending on the run configuration.
     
@@ -53,4 +52,4 @@ def get_model(cfg: Config) -> nn.Module:
     else:
         raise NotImplementedError(f"{cfg.model} not implemented or not linked in `get_model()`")
 
-    return model
+    return torch.compile(model, mode="max-autotune")


### PR DESCRIPTION
When moved the call as a decorator, the `@` was missed, resulting in the model not being compiled.

However, using a decorator doesn't work since it works only with torch nn.modules. So this moves the line to the correct location and as an invocation.