### PR TITLE
Setup merge's join explicitly.

### DIFF
--- a/neuralhydrology/datasetzoo/multimet.py
+++ b/neuralhydrology/datasetzoo/multimet.py
@@ -541,7 +541,7 @@ class Multimet(Dataset):
         if not datasets:
             raise ValueError("At least one type of data must be loaded.")
         LOGGER.debug("merge")
-        return xr.merge(datasets)
+        return xr.merge(datasets, join='outer')
 
     def _load_hindcast_features(self) -> list[xr.Dataset]:
         """Load Caravan-Multimet data for hindcast features.


### PR DESCRIPTION
Addresses the warning
```
/usr/local/google/home/amarkel/flood-forecasting/neuralhydrology/datasetzoo/multimet.py:544: FutureWarning: In a future version of xarray the default value for join will change from join='outer' to join='exact'. This change will result in the following ValueError: cannot be aligned with join='exact' because index/labels/sizes are not equal along these coordinates (dimensions): 'date' ('date',) The recommendation is to set join explicitly for this case.
  return xr.merge(datasets)
```

`join='exact'` can't be used now.