### PR TITLE
Setup open_mfdataset join explicitly.

### DIFF
--- a/neuralhydrology/datasetzoo/caravan.py
+++ b/neuralhydrology/datasetzoo/caravan.py
@@ -186,6 +186,7 @@ def load_caravan_timeseries_together(
         concat_dim="basin",
         parallel=False,  # open_mfdataset has a bug (seg fault) when True
         chunks={"date": "auto"},
+        join='outer',
     )
     return ds.assign_coords(basin=basins)
 


### PR DESCRIPTION
Addresses the warning
```
/usr/local/google/home/amarkel/flood-forecasting/neuralhydrology/datasetzoo/caravan.py:182: FutureWarning: In a future version of xarray the default value for join will change from join='outer' to join='exact'. This change will result in the following ValueError: cannot be aligned with join='exact' because index/labels/sizes are not equal along these coordinates (dimensions): 'date' ('date',) The recommendation is to set join explicitly for this case.
  ds = xarray.open_mfdataset(
```

`join='exact'` may be used but it's slower.