### PR TITLE
Setup caravan csv merging join explicitly.

### DIFF
--- a/neuralhydrology/datasetzoo/caravan.py
+++ b/neuralhydrology/datasetzoo/caravan.py
@@ -209,4 +209,4 @@ def _load_attribute_files_of_subdatasets(datasets: list[Path], features: List[st
     dss = map(process, itertools.chain.from_iterable(e.glob("*.csv") for e in datasets))
     dss = dask.compute(*dss)
 
-    return xarray.merge(dss)
+    return xarray.merge(dss, join='outer')


### PR DESCRIPTION
Addressing warning
```
/usr/local/google/home/amarkel/flood-forecasting/neuralhydrology/datasetzoo/caravan.py:212: FutureWarning: In a future version of xarray the default value for compat will change from compat='no_conflicts' to compat='override'. This is likely to lead to different results when combining overlapping variables with the same name. To opt in to new defaults and get rid of these warnings now use `set_options(use_new_combine_kwarg_defaults=True) or set compat explicitly.
  return xarray.merge(dss)
```

First with `join='outer'`.