### PR TITLE
Setup compat='no_conflicts' explicitly in caravan merge

### DIFF
--- a/neuralhydrology/datasetzoo/caravan.py
+++ b/neuralhydrology/datasetzoo/caravan.py
@@ -210,4 +210,4 @@ def _load_attribute_files_of_subdatasets(datasets: list[Path], features: list[st
     dss = map(process, itertools.chain.from_iterable(e.glob("*.csv") for e in datasets))
     dss = dask.compute(*dss)
 
-    return xarray.merge(dss, join='outer')
+    return xarray.merge(dss, join='outer', compat='no_conflicts')


### PR DESCRIPTION
Addresses warning
```
/usr/local/google/home/amarkel/flood-forecasting/neuralhydrology/datasetzoo/caravan.py:212: FutureWarning: In a future version of xarray the default value for compat will change from compat='no_conflicts' to compat='override'. This is likely to lead to different results when combining overlapping variables with the same name. To opt in to new defaults and get rid of these warnings now use `set_options(use_new_combine_kwarg_defaults=True) or set compat explicitly.
  return xarray.merge(dss)
  ```
  by using `compat='no_conflicts'`.

  There shouldn't be overlaps of the same data in different files, so retaining this check is helpful.