### PR TITLE
Setup learning rate epochs drop to 0.

### DIFF
--- a/config/multimet_mean_embedding_forecast_lstm.yml
+++ b/config/multimet_mean_embedding_forecast_lstm.yml
@@ -26,7 +26,7 @@ clip_targets_to_zero:
 learning_rate_strategy: ReduceLROnPlateau
 initial_learning_rate: 0.0005
 learning_rate_drop_factor: 0.1
-learning_rate_epochs_drop: 1
+learning_rate_epochs_drop: 0
 # max_updates_per_epoch:
 max_updates_per_epoch: 2000
 metrics:


### PR DESCRIPTION
This is the amount of epocs to hold off LR reduction. When 1, it means that e.g. given two epocs where loss didn't decrease (along with a threshold by default) or increase, an additional 1 epoc is made prior to reducing LR.

Loss should be reduced each epoc. So this value may be 0 instead to avoid wasteful epocs when LR should be stepped down.