### PR TITLE
Filter out warning logs that were already reported.

### DIFF
--- a/config/multimet_mean_embedding_forecast_lstm.yml
+++ b/config/multimet_mean_embedding_forecast_lstm.yml
@@ -14,6 +14,7 @@
 
 logging_level: INFO
 detect_anomaly: False
+print_warnings_once: False
 
 # --- Training Parameters -------------------------------------------------------
 

--- a/googlehydrology/run.py
+++ b/googlehydrology/run.py
@@ -57,7 +57,7 @@ def _main():
     config = Config(Path(args["config_file"] or Path(args["run_dir"]) / "config.yml"))
 
     if (args["run_dir"] is not None) and (args["mode"] in ["evaluate", "infer"]):
-        setup_logging(str(Path(args["run_dir"]) / "output.log"), config.logging_level)
+        setup_logging(str(Path(args["run_dir"]) / "output.log"), config.logging_level, config.print_warnings_once)
 
     torch.autograd.set_detect_anomaly(config.detect_anomaly)
 

--- a/googlehydrology/training/basetrainer.py
+++ b/googlehydrology/training/basetrainer.py
@@ -74,7 +74,7 @@ class BaseTrainer(object):
         self._epoch = self._get_start_epoch_number()
 
         self._create_folder_structure()
-        setup_logging(str(self.cfg.run_dir / "output.log"), cfg.logging_level)
+        setup_logging(str(self.cfg.run_dir / "output.log"), cfg.logging_level, cfg.print_warnings_once)
         LOGGER.info(f"### Folder structure created at {self.cfg.run_dir}")
 
         if self.cfg.is_continue_training:

--- a/googlehydrology/utils/config.py
+++ b/googlehydrology/utils/config.py
@@ -281,6 +281,10 @@ class Config(object):
         return self._cfg.get("detect_anomaly", False)
 
     @property
+    def print_warnings_once(self) -> bool:
+        return self._cfg.get("print_warnings_once", False)
+
+    @property
     def tester_skip_obs_all_nan(self) -> bool:
         return self._cfg.get("tester_skip_obs_all_nan", False)
 

--- a/googlehydrology/utils/logging_utils.py
+++ b/googlehydrology/utils/logging_utils.py
@@ -23,20 +23,20 @@ LOGGER = logging.getLogger(__name__)
 class WarningOnceFilter(logging.Filter):
     """Filters out non-unique warnings."""
 
-    def __init__(self, name: str = '') -> None:
-        super().__init__(name)
+    def __init__(self) -> None:
+        super().__init__()
         self._seen = set()
 
     def filter(self, record: logging.LogRecord) -> bool:
         if record.levelno != logging.WARNING:
-            return True
+            return True  # No effect for non-warning
 
-        serialized = repr(record)
-        if serialized in self._seen:
-            return False
+        if (cmp := repr(record)) in self._seen:
+            return False  # Filter out (already seen)
+        self._seen.add(cmp)
 
-        self._seen.add(serialized)
-        return True
+        return True  # First seen so printed
+
 
 def setup_logging(log_file: str, level: int):
     """Initialize logging to `log_file` and stdout.

--- a/googlehydrology/utils/logging_utils.py
+++ b/googlehydrology/utils/logging_utils.py
@@ -20,6 +20,23 @@ from typing import Optional
 
 LOGGER = logging.getLogger(__name__)
 
+class WarningOnceFilter(logging.Filter):
+    """Filters out non-unique warnings."""
+
+    def __init__(self, name: str = '') -> None:
+        super().__init__(name)
+        self._seen = set()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno != logging.WARNING:
+            return True
+
+        serialized = repr(record)
+        if serialized in self._seen:
+            return False
+
+        self._seen.add(serialized)
+        return True
 
 def setup_logging(log_file: str, level: int):
     """Initialize logging to `log_file` and stdout.
@@ -31,6 +48,9 @@ def setup_logging(log_file: str, level: int):
     level : int
         Py logging level to print from from.
     """
+    logging.captureWarnings(True)
+    logging.getLogger('py.warnings').addFilter(WarningOnceFilter())
+
     file_handler = logging.FileHandler(filename=log_file)
     stdout_handler = logging.StreamHandler(sys.stdout)
 

--- a/googlehydrology/utils/logging_utils.py
+++ b/googlehydrology/utils/logging_utils.py
@@ -38,7 +38,7 @@ class WarningOnceFilter(logging.Filter):
         return True  # First seen so printed
 
 
-def setup_logging(log_file: str, level: int):
+def setup_logging(log_file: str, level: int, print_warnings_once: bool):
     """Initialize logging to `log_file` and stdout.
 
     Parameters
@@ -47,9 +47,12 @@ def setup_logging(log_file: str, level: int):
         Name of the file that will be logged to.
     level : int
         Py logging level to print from from.
+    print_warnings_once : bool
+        Whether to filter warnings that same line type and msg.
     """
     logging.captureWarnings(True)
-    logging.getLogger('py.warnings').addFilter(WarningOnceFilter())
+    if print_warnings_once:
+        logging.getLogger('py.warnings').addFilter(WarningOnceFilter())
 
     file_handler = logging.FileHandler(filename=log_file)
     stdout_handler = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
This affects mainly `infer` mode where the same warnings are printed several times on every iteration otherwise.