### PR TITLE
Remove default ctor param value.

### DIFF
--- a/googlehydrology/evaluation/utils.py
+++ b/googlehydrology/evaluation/utils.py
@@ -93,7 +93,7 @@ class BasinBatchSampler(BatchSampler):
         self,
         sample_index: dict[int, dict[str, int]],
         batch_size: int,
-        basins_indexes: set[int] = set(),
+        basins_indexes: set[int],
     ):
         super().__init__(SequentialSampler(range(len(sample_index))), batch_size, drop_last=False)
 

--- a/test/test_tester.py
+++ b/test/test_tester.py
@@ -57,7 +57,7 @@ def fixure():
 
 def test_init_groups_basins(fixure):
     """Test grouping all sample indices by their basin id."""
-    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3)
+    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3, basins_indexes=set())
 
     assert sampler._basin_indices == fixure["expected_groups"]
 
@@ -70,7 +70,7 @@ def test_init_groups_basins_subset(fixure):
 
 def test_num_batches(fixure):
     """Test _num_batches is total num batches for an epoc (accounting for partial batch)."""
-    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3)
+    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3, basins_indexes=set())
 
     expected_num_batches = ceil(7 / 3) + ceil(6 / 3) + ceil(2 / 3)
 
@@ -79,7 +79,7 @@ def test_num_batches(fixure):
 
 def test_len_returns_num_batches(fixure):
     """Test __len__ returns total num batches for an epoc (accounting for partial batch)."""
-    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3)
+    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3, basins_indexes=set())
 
     expected_num_batches = ceil(7 / 3) + ceil(6 / 3) + ceil(2 / 3)
 
@@ -88,7 +88,7 @@ def test_len_returns_num_batches(fixure):
 
 def test_iter_yields_all_samples_once(fixure):
     """Test iterating results in all sample indices once per epoc."""
-    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3)
+    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3, basins_indexes=set())
 
     indices = {i for batch in sampler for i in batch}
 
@@ -97,7 +97,7 @@ def test_iter_yields_all_samples_once(fixure):
 
 def test_one_basin_per_batch(fixure):
     """Test every batch contains samples belonging to only one basin."""
-    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3)
+    sampler = BasinBatchSampler(fixure["sample_index"], batch_size=3, basins_indexes=set())
 
     basinss = [{fixure["sample_index"][i]["basin"] for i in batch} for batch in sampler]
     assert all(len(basins) == 1 for basins in basinss)
@@ -108,7 +108,7 @@ def test_sampler_with_single_basin(fixure):
     sample_index = {
         k: v for k, v in fixure["sample_index"].items() if v["basin"] == 101
     }
-    sampler = BasinBatchSampler(sample_index, batch_size=3)
+    sampler = BasinBatchSampler(sample_index, batch_size=3, basins_indexes=set())
 
     indices = {idx for batch in sampler for idx in batch}
 
@@ -119,7 +119,7 @@ def test_sampler_with_single_basin(fixure):
 def test_sampler_with_batch_size_larger_than_samples():
     """Test behavior when a basin has fewer samples than the batch size."""
     sample_index = {0: {"basin": 201}, 1: {"basin": 201}}
-    sampler = BasinBatchSampler(sample_index, batch_size=5)
+    sampler = BasinBatchSampler(sample_index, batch_size=5, basins_indexes=set())
     batches = list(sampler)
 
     assert len(sampler) == 1


### PR DESCRIPTION
It's actually a global variable. It's safer to always specify it or pass eg None. It makes less sense as API to have a default here though.