### PR TITLE
Add weight_init_opts: first add xavier for ih lstm and fc

### DIFF
--- a/config/multimet_handoff_forecast_lstm.yml
+++ b/config/multimet_handoff_forecast_lstm.yml
@@ -41,7 +41,7 @@ predict_last_n: 8
 regularization:
 - forecast_overlap
 log_loss_every_nth_update: 8
-use_advanced_init: False
+weight_init_opts:
  
 # --- Dataset Parameters --------------------------------------------------------
 train_basin_file: ~/flood-forecasting/config/basins/caravan_3_basins.txt

--- a/config/multimet_handoff_forecast_lstm.yml
+++ b/config/multimet_handoff_forecast_lstm.yml
@@ -41,6 +41,7 @@ predict_last_n: 8
 regularization:
 - forecast_overlap
 log_loss_every_nth_update: 8
+use_xavier_init: False
  
 # --- Dataset Parameters --------------------------------------------------------
 train_basin_file: ~/flood-forecasting/config/basins/caravan_3_basins.txt

--- a/config/multimet_handoff_forecast_lstm.yml
+++ b/config/multimet_handoff_forecast_lstm.yml
@@ -41,7 +41,7 @@ predict_last_n: 8
 regularization:
 - forecast_overlap
 log_loss_every_nth_update: 8
-use_xavier_init: False
+use_advanced_init: False
  
 # --- Dataset Parameters --------------------------------------------------------
 train_basin_file: ~/flood-forecasting/config/basins/caravan_3_basins.txt

--- a/config/multimet_mean_embedding_forecast_lstm.yml
+++ b/config/multimet_mean_embedding_forecast_lstm.yml
@@ -46,7 +46,7 @@ predict_last_n: 8
 log_n_figures: 5
 log_loss_every_nth_update: 50
 allzero_samples_are_invalid: False
-use_xavier_init: False
+use_advanced_init: False
 
 # --- Dataset Parameters --------------------------------------------------------
 

--- a/config/multimet_mean_embedding_forecast_lstm.yml
+++ b/config/multimet_mean_embedding_forecast_lstm.yml
@@ -46,6 +46,7 @@ predict_last_n: 8
 log_n_figures: 5
 log_loss_every_nth_update: 50
 allzero_samples_are_invalid: False
+use_xavier_init: False
 
 # --- Dataset Parameters --------------------------------------------------------
 

--- a/config/multimet_mean_embedding_forecast_lstm.yml
+++ b/config/multimet_mean_embedding_forecast_lstm.yml
@@ -46,7 +46,7 @@ predict_last_n: 8
 log_n_figures: 5
 log_loss_every_nth_update: 50
 allzero_samples_are_invalid: False
-use_advanced_init: False
+weight_init_opts:
 
 # --- Dataset Parameters --------------------------------------------------------
 

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -148,7 +148,7 @@ General model configuration
 -  ``initial_forget_bias``: Initial value of the forget gate bias.
 
 -  ``weight_init_opts``: Non-default weight initializer list for FCs, LSTMs, etc.
-   Every item may be one of `WeightInitOpt`: ih-xavier, fc-xavier
+   Every item may be one of `WeightInitOpt`: lstm-ih-xavier, fc-xavier
 
 -  ``output_dropout``: Dropout applied to the output of the LSTM
 

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -147,6 +147,9 @@ General model configuration
 
 -  ``initial_forget_bias``: Initial value of the forget gate bias.
 
+-  ``use_xavier_init``: Whether to use `torch.nn.init.xavier_uniform_` for FC networks, LSTMs, etc, instead
+   of a plain uniform or constant initial weights. Default is False.
+
 -  ``output_dropout``: Dropout applied to the output of the LSTM
 
 Regression head

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -147,8 +147,8 @@ General model configuration
 
 -  ``initial_forget_bias``: Initial value of the forget gate bias.
 
--  ``use_advanced_init``: Whether to use xavier as initial weights for FC networks, LSTMs, etc.
-   Default is False.
+-  ``weight_init_opts``: Non-default weight initializer list for FCs, LSTMs, etc.
+   Every item may be one of `WeightInitOpt`: ih-xavier, fc-xavier
 
 -  ``output_dropout``: Dropout applied to the output of the LSTM
 

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -147,8 +147,8 @@ General model configuration
 
 -  ``initial_forget_bias``: Initial value of the forget gate bias.
 
--  ``use_xavier_init``: Whether to use `torch.nn.init.xavier_uniform_` for FC networks, LSTMs, etc, instead
-   of a plain uniform or constant initial weights. Default is False.
+-  ``use_advanced_init``: Whether to use xavier as initial weights for FC networks, LSTMs, etc.
+   Default is False.
 
 -  ``output_dropout``: Dropout applied to the output of the LSTM
 

--- a/googlehydrology/modelzoo/fc.py
+++ b/googlehydrology/modelzoo/fc.py
@@ -36,12 +36,14 @@ class FC(nn.Module):
         Activation function for intermediate layers, default tanh.
     dropout : float, optional
         Dropout rate in intermediate layers.
+    fc_xavier : bool, optional
+        Whether to use xavier as init method.
     """
 
-    def __init__(self, input_size: int, hidden_sizes: list[int], activation: str | list[str] = 'tanh', dropout: float = 0.0, advanced: bool = False):
+    def __init__(self, input_size: int, hidden_sizes: list[int], activation: str | list[str] = 'tanh', dropout: float = 0.0, fc_xavier: bool = False):
         super(FC, self).__init__()
 
-        self._advanced = advanced
+        self._xavier = fc_xavier
 
         if len(hidden_sizes) == 0:
             raise ValueError('hidden_sizes must at least have one entry to create a fully-connected net.')
@@ -92,7 +94,7 @@ class FC(nn.Module):
             if isinstance(layer, nn.modules.linear.Linear):
                 n_in = layer.weight.shape[1]
                 gain = np.sqrt(3 / n_in)
-                if self._advanced:
+                if self._xavier:
                     nn.init.xavier_uniform_(layer.weight, gain)
                 else:
                     nn.init.uniform_(layer.weight, -gain, gain)

--- a/googlehydrology/modelzoo/fc.py
+++ b/googlehydrology/modelzoo/fc.py
@@ -38,10 +38,10 @@ class FC(nn.Module):
         Dropout rate in intermediate layers.
     """
 
-    def __init__(self, input_size: int, hidden_sizes: list[int], activation: str | list[str] = 'tanh', dropout: float = 0.0, xavier: bool = False):
+    def __init__(self, input_size: int, hidden_sizes: list[int], activation: str | list[str] = 'tanh', dropout: float = 0.0, advanced: bool = False):
         super(FC, self).__init__()
 
-        self._xavier = xavier
+        self._advanced = advanced
 
         if len(hidden_sizes) == 0:
             raise ValueError('hidden_sizes must at least have one entry to create a fully-connected net.')
@@ -92,7 +92,7 @@ class FC(nn.Module):
             if isinstance(layer, nn.modules.linear.Linear):
                 n_in = layer.weight.shape[1]
                 gain = np.sqrt(3 / n_in)
-                if self._xavier:
+                if self._advanced:
                     nn.init.xavier_uniform_(layer.weight, gain)
                 else:
                     nn.init.uniform_(layer.weight, -gain, gain)

--- a/googlehydrology/modelzoo/fc.py
+++ b/googlehydrology/modelzoo/fc.py
@@ -38,8 +38,10 @@ class FC(nn.Module):
         Dropout rate in intermediate layers.
     """
 
-    def __init__(self, input_size: int, hidden_sizes: list[int], activation: str | list[str] = 'tanh', dropout: float = 0.0):
+    def __init__(self, input_size: int, hidden_sizes: list[int], activation: str | list[str] = 'tanh', dropout: float = 0.0, xavier: bool = False):
         super(FC, self).__init__()
+
+        self._xavier = xavier
 
         if len(hidden_sizes) == 0:
             raise ValueError('hidden_sizes must at least have one entry to create a fully-connected net.')
@@ -90,7 +92,10 @@ class FC(nn.Module):
             if isinstance(layer, nn.modules.linear.Linear):
                 n_in = layer.weight.shape[1]
                 gain = np.sqrt(3 / n_in)
-                nn.init.uniform_(layer.weight, -gain, gain)
+                if self._xavier:
+                    nn.init.xavier_uniform_(layer.weight, gain)
+                else:
+                    nn.init.uniform_(layer.weight, -gain, gain)
                 nn.init.constant_(layer.bias, val=0)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/googlehydrology/modelzoo/fc.py
+++ b/googlehydrology/modelzoo/fc.py
@@ -36,14 +36,14 @@ class FC(nn.Module):
         Activation function for intermediate layers, default tanh.
     dropout : float, optional
         Dropout rate in intermediate layers.
-    fc_xavier : bool, optional
+    xavier_init : bool, optional
         Whether to use xavier as init method.
     """
 
-    def __init__(self, input_size: int, hidden_sizes: list[int], activation: str | list[str] = 'tanh', dropout: float = 0.0, fc_xavier: bool = False):
+    def __init__(self, input_size: int, hidden_sizes: list[int], activation: str | list[str] = 'tanh', dropout: float = 0.0, xavier_init: bool = False):
         super(FC, self).__init__()
 
-        self._xavier = fc_xavier
+        self._xavier_init = xavier_init
 
         if len(hidden_sizes) == 0:
             raise ValueError('hidden_sizes must at least have one entry to create a fully-connected net.')
@@ -94,7 +94,7 @@ class FC(nn.Module):
             if isinstance(layer, nn.modules.linear.Linear):
                 n_in = layer.weight.shape[1]
                 gain = np.sqrt(3 / n_in)
-                if self._xavier:
+                if self._xavier_init:
                     nn.init.xavier_uniform_(layer.weight, gain)
                 else:
                     nn.init.uniform_(layer.weight, -gain, gain)

--- a/googlehydrology/modelzoo/handoff_forecast_lstm.py
+++ b/googlehydrology/modelzoo/handoff_forecast_lstm.py
@@ -100,14 +100,14 @@ class HandoffForecastLSTM(BaseModel):
             hidden_sizes=cfg.state_handoff_network['hiddens'],
             activation=cfg.state_handoff_network['activation'],
             dropout=cfg.state_handoff_network['dropout'],
-            fc_xavier=FC_XAVIER in cfg.weight_init_opts,
+            xavier_init=FC_XAVIER in cfg.weight_init_opts,
         )
         self.handoff_linear = FC(
             input_size=cfg.state_handoff_network['hiddens'][-1],
             hidden_sizes=[self.forecast_hidden_size*2],
             activation='linear',
             dropout=0.0,
-            fc_xavier=FC_XAVIER in cfg.weight_init_opts,
+            xavier_init=FC_XAVIER in cfg.weight_init_opts,
         )
 
         # Head layers.

--- a/googlehydrology/modelzoo/handoff_forecast_lstm.py
+++ b/googlehydrology/modelzoo/handoff_forecast_lstm.py
@@ -96,13 +96,15 @@ class HandoffForecastLSTM(BaseModel):
             input_size=self.hindcast_hidden_size*2,
             hidden_sizes=cfg.state_handoff_network['hiddens'],
             activation=cfg.state_handoff_network['activation'],
-            dropout=cfg.state_handoff_network['dropout']
+            dropout=cfg.state_handoff_network['dropout'],
+            xavier=cfg.use_xavier_init,
         )
         self.handoff_linear = FC(
             input_size=cfg.state_handoff_network['hiddens'][-1],
             hidden_sizes=[self.forecast_hidden_size*2],
             activation='linear',
-            dropout=0.0
+            dropout=0.0,
+            xavier=cfg.use_xavier_init,
         )
 
         # Head layers.

--- a/googlehydrology/modelzoo/handoff_forecast_lstm.py
+++ b/googlehydrology/modelzoo/handoff_forecast_lstm.py
@@ -98,14 +98,14 @@ class HandoffForecastLSTM(BaseModel):
             hidden_sizes=cfg.state_handoff_network['hiddens'],
             activation=cfg.state_handoff_network['activation'],
             dropout=cfg.state_handoff_network['dropout'],
-            xavier=cfg.use_advanced_init,
+            advanced=cfg.use_advanced_init,
         )
         self.handoff_linear = FC(
             input_size=cfg.state_handoff_network['hiddens'][-1],
             hidden_sizes=[self.forecast_hidden_size*2],
             activation='linear',
             dropout=0.0,
-            xavier=cfg.use_advanced_init,
+            advanced=cfg.use_advanced_init,
         )
 
         # Head layers.

--- a/googlehydrology/modelzoo/handoff_forecast_lstm.py
+++ b/googlehydrology/modelzoo/handoff_forecast_lstm.py
@@ -117,11 +117,16 @@ class HandoffForecastLSTM(BaseModel):
 
     def _reset_parameters(self):
         """Special initialization of certain model weights."""
-        if self.cfg.initial_forget_bias is not None:
-            self.hindcast_lstm.bias_hh_l0.data[
-                self.hindcast_hidden_size:2*self.hindcast_hidden_size] = self.cfg.initial_forget_bias
-            self.forecast_lstm.bias_hh_l0.data[
-                self.forecast_hidden_size:2*self.forecast_hidden_size] = self.cfg.initial_forget_bias
+        for name, param in self.hindcast_lstm.named_parameters():
+            if 'weight' in name and self.cfg.use_xavier_init:
+                nn.init.xavier_uniform_(param.data)
+            elif 'bias' in name and self.cfg.initial_forget_bias is not None:
+                nn.init.constant_(param.data, self.cfg.initial_forget_bias)
+        for name, param in self.forecast_lstm.named_parameters():
+            if 'weight' in name and self.cfg.use_xavier_init:
+                nn.init.xavier_uniform_(param.data)
+            elif 'bias' in name and self.cfg.initial_forget_bias is not None:
+                nn.init.constant_(param.data, self.cfg.initial_forget_bias)
 
     def forward(
         self,

--- a/googlehydrology/modelzoo/handoff_forecast_lstm.py
+++ b/googlehydrology/modelzoo/handoff_forecast_lstm.py
@@ -24,7 +24,7 @@ from googlehydrology.modelzoo.fc import FC
 from googlehydrology.modelzoo.head import get_head
 from googlehydrology.modelzoo.inputlayer import InputLayer
 
-IH_XAVIER = WeightInitOpt.IH_XAVIER
+LSTM_IH_XAVIER = WeightInitOpt.LSTM_IH_XAVIER
 FC_XAVIER = WeightInitOpt.FC_XAVIER
 
 class HandoffForecastLSTM(BaseModel):
@@ -128,7 +128,7 @@ class HandoffForecastLSTM(BaseModel):
 
         lstms = self.hindcast_lstm, self.forecast_lstm
         for name, param in flatten(e.named_parameters() for e in lstms):
-            if 'weight_ih' in name and IH_XAVIER in self.cfg.weight_init_opts:
+            if 'weight_ih' in name and LSTM_IH_XAVIER in self.cfg.weight_init_opts:
                 nn.init.xavier_uniform_(param)
 
     def forward(

--- a/googlehydrology/modelzoo/inputlayer.py
+++ b/googlehydrology/modelzoo/inputlayer.py
@@ -165,7 +165,7 @@ class InputLayer(nn.Module):
         self.cfg = cfg
         
     @staticmethod
-    def _get_embedding_net(embedding_spec: Optional[dict], input_size: int, purpose: str, xavier: bool) -> tuple[nn.Module, int]:
+    def _get_embedding_net(embedding_spec: Optional[dict], input_size: int, purpose: str, advanced: bool) -> tuple[nn.Module, int]:
         """Get an embedding net following the passed specifications.
 
         If the `embedding_spec` is None, the returned embedding net will be the identity function.
@@ -178,7 +178,7 @@ class InputLayer(nn.Module):
             Size of the inputs into the embedding network.
         purpose : str
             Purpose of the embedding network, used for error messages.
-        xavier : bool
+        advanced : bool
             Whether to init the FC with the xavier method.
 
         Returns
@@ -203,7 +203,7 @@ class InputLayer(nn.Module):
         dropout = embedding_spec['dropout']
         activation = embedding_spec['activation']
 
-        emb_net = FC(input_size=input_size, hidden_sizes=hiddens, activation=activation, dropout=dropout, xavier=xavier)
+        emb_net = FC(input_size=input_size, hidden_sizes=hiddens, activation=activation, dropout=dropout, advanced=advanced)
         return emb_net, emb_net.output_size
 
     def forward(self, data: dict[str, torch.Tensor | dict[str, torch.Tensor]], concatenate_output: bool = True) \

--- a/googlehydrology/modelzoo/inputlayer.py
+++ b/googlehydrology/modelzoo/inputlayer.py
@@ -118,7 +118,7 @@ class InputLayer(nn.Module):
             statics_input_size += cfg.number_of_basins
 
         self.statics_embedding, self.statics_output_size = \
-            self._get_embedding_net(cfg.statics_embedding, statics_input_size, 'statics', cfg.use_xavier_init)
+            self._get_embedding_net(cfg.statics_embedding, statics_input_size, 'statics', cfg.use_advanced_init)
 
         self._pos_enc = None
         if cfg.nan_handling_pos_encoding_size > 0:
@@ -135,7 +135,7 @@ class InputLayer(nn.Module):
             group_embedding, group_output_size = self._get_embedding_net(cfg.dynamics_embedding,
                                                                          dynamics_input_size,
                                                                          'dynamics',
-                                                                         cfg.use_xavier_init)
+                                                                         cfg.use_advanced_init)
             dynamics_embeddings.append(group_embedding)
             dynamics_output_sizes.append(group_output_size)
         self.dynamics_embeddings = nn.ModuleList(dynamics_embeddings)
@@ -150,7 +150,7 @@ class InputLayer(nn.Module):
                                             (self.statics_output_size + len(self._dynamic_inputs)
                                              + cfg.nan_handling_pos_encoding_size),
                                             'query',
-                                            cfg.use_xavier_init)
+                                            cfg.use_advanced_init)
 
         if cfg.statics_embedding is None:
             self.statics_embedding_p_dropout = 0.0  # if net has no statics dropout we treat is as zero

--- a/googlehydrology/modelzoo/inputlayer.py
+++ b/googlehydrology/modelzoo/inputlayer.py
@@ -21,7 +21,7 @@ import torch.nn as nn
 
 from googlehydrology.modelzoo.fc import FC
 from googlehydrology.modelzoo.positional_encoding import PositionalEncoding
-from googlehydrology.utils.config import Config
+from googlehydrology.utils.config import Config, WeightInitOpt
 
 LOGGER = logging.getLogger(__name__)
 
@@ -117,8 +117,10 @@ class InputLayer(nn.Module):
         if cfg.use_basin_id_encoding:
             statics_input_size += cfg.number_of_basins
 
+        fc_xavier = WeightInitOpt.FC_XAVIER in cfg.weight_init_opts
+
         self.statics_embedding, self.statics_output_size = \
-            self._get_embedding_net(cfg.statics_embedding, statics_input_size, 'statics', cfg.use_advanced_init)
+            self._get_embedding_net(cfg.statics_embedding, statics_input_size, 'statics', fc_xavier)
 
         self._pos_enc = None
         if cfg.nan_handling_pos_encoding_size > 0:
@@ -135,7 +137,7 @@ class InputLayer(nn.Module):
             group_embedding, group_output_size = self._get_embedding_net(cfg.dynamics_embedding,
                                                                          dynamics_input_size,
                                                                          'dynamics',
-                                                                         cfg.use_advanced_init)
+                                                                         fc_xavier)
             dynamics_embeddings.append(group_embedding)
             dynamics_output_sizes.append(group_output_size)
         self.dynamics_embeddings = nn.ModuleList(dynamics_embeddings)
@@ -150,7 +152,7 @@ class InputLayer(nn.Module):
                                             (self.statics_output_size + len(self._dynamic_inputs)
                                              + cfg.nan_handling_pos_encoding_size),
                                             'query',
-                                            cfg.use_advanced_init)
+                                            fc_xavier)
 
         if cfg.statics_embedding is None:
             self.statics_embedding_p_dropout = 0.0  # if net has no statics dropout we treat is as zero
@@ -165,7 +167,7 @@ class InputLayer(nn.Module):
         self.cfg = cfg
         
     @staticmethod
-    def _get_embedding_net(embedding_spec: Optional[dict], input_size: int, purpose: str, advanced: bool) -> tuple[nn.Module, int]:
+    def _get_embedding_net(embedding_spec: Optional[dict], input_size: int, purpose: str, fc_xavier: bool) -> tuple[nn.Module, int]:
         """Get an embedding net following the passed specifications.
 
         If the `embedding_spec` is None, the returned embedding net will be the identity function.
@@ -178,7 +180,7 @@ class InputLayer(nn.Module):
             Size of the inputs into the embedding network.
         purpose : str
             Purpose of the embedding network, used for error messages.
-        advanced : bool
+        fc_xavier : bool
             Whether to init the FC with the xavier method.
 
         Returns
@@ -203,7 +205,7 @@ class InputLayer(nn.Module):
         dropout = embedding_spec['dropout']
         activation = embedding_spec['activation']
 
-        emb_net = FC(input_size=input_size, hidden_sizes=hiddens, activation=activation, dropout=dropout, advanced=advanced)
+        emb_net = FC(input_size=input_size, hidden_sizes=hiddens, activation=activation, dropout=dropout, fc_xavier=fc_xavier)
         return emb_net, emb_net.output_size
 
     def forward(self, data: dict[str, torch.Tensor | dict[str, torch.Tensor]], concatenate_output: bool = True) \

--- a/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
+++ b/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
@@ -146,7 +146,7 @@ class MeanEmbeddingForecastLSTM(BaseModel):
             hidden_sizes=hiddens,
             activation=activation,
             dropout=dropout,
-            fc_xavier=FC_XAVIER in self.cfg.weight_init_opts,
+            xavier_init=FC_XAVIER in self.cfg.weight_init_opts,
         )
 
     def _reset_parameters(self):

--- a/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
+++ b/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
@@ -102,6 +102,10 @@ class MeanEmbeddingForecastLSTM(BaseModel):
             hidden_size=self.config_data.hidden_size,
             batch_first=True,
         )
+        if cfg.use_xavier_init:
+            for name, param in self.hindcast_lstm.named_parameters():
+                if 'weight' in name:
+                    nn.init.xavier_uniform_(param.data)
 
         # Forecast LSTM
         self.forecast_lstm = nn.LSTM(
@@ -110,6 +114,10 @@ class MeanEmbeddingForecastLSTM(BaseModel):
             hidden_size=self.config_data.hidden_size,
             batch_first=True,
         )
+        if cfg.use_xavier_init:
+            for name, param in self.forecast_lstm.named_parameters():
+                if 'weight' in name:
+                    nn.init.xavier_uniform_(param.data)
 
         # Head
         self.dropout = nn.Dropout(p=cfg.output_dropout)
@@ -140,6 +148,7 @@ class MeanEmbeddingForecastLSTM(BaseModel):
             hidden_sizes=hiddens,
             activation=activation,
             dropout=dropout,
+            xavier=self.cfg.use_xavier_init,
         )
 
     def _reset_parameters(self):

--- a/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
+++ b/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
@@ -23,9 +23,11 @@ from more_itertools import flatten
 from googlehydrology.modelzoo.basemodel import BaseModel
 from googlehydrology.modelzoo.fc import FC
 from googlehydrology.modelzoo.head import get_head
-from googlehydrology.utils.config import Config
+from googlehydrology.utils.config import Config, WeightInitOpt
 from googlehydrology.utils.configutils import group_by_prefix
 
+IH_XAVIER = WeightInitOpt.IH_XAVIER
+FC_XAVIER = WeightInitOpt.FC_XAVIER
 
 class MeanEmbeddingForecastLSTM(BaseModel):
     """A forecasting model using mean embedding and LSTMs for hindcast and forecast.
@@ -144,7 +146,7 @@ class MeanEmbeddingForecastLSTM(BaseModel):
             hidden_sizes=hiddens,
             activation=activation,
             dropout=dropout,
-            advanced=self.cfg.use_advanced_init,
+            fc_xavier=FC_XAVIER in self.cfg.weight_init_opts,
         )
 
     def _reset_parameters(self):
@@ -159,7 +161,7 @@ class MeanEmbeddingForecastLSTM(BaseModel):
 
         lstms = self.hindcast_lstm, self.forecast_lstm
         for name, param in flatten(e.named_parameters() for e in lstms):
-            if 'weight_ih' in name and self.cfg.use_advanced_init:
+            if 'weight_ih' in name and IH_XAVIER in self.cfg.weight_init_opts:
                 nn.init.xavier_uniform_(param)
 
     def forward(

--- a/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
+++ b/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
@@ -141,7 +141,7 @@ class MeanEmbeddingForecastLSTM(BaseModel):
             hidden_sizes=hiddens,
             activation=activation,
             dropout=dropout,
-            xavier=self.cfg.use_advanced_init,
+            advanced=self.cfg.use_advanced_init,
         )
 
     def _reset_parameters(self):

--- a/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
+++ b/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
@@ -26,7 +26,7 @@ from googlehydrology.modelzoo.head import get_head
 from googlehydrology.utils.config import Config, WeightInitOpt
 from googlehydrology.utils.configutils import group_by_prefix
 
-IH_XAVIER = WeightInitOpt.IH_XAVIER
+LSTM_IH_XAVIER = WeightInitOpt.LSTM_IH_XAVIER
 FC_XAVIER = WeightInitOpt.FC_XAVIER
 
 class MeanEmbeddingForecastLSTM(BaseModel):
@@ -161,7 +161,7 @@ class MeanEmbeddingForecastLSTM(BaseModel):
 
         lstms = self.hindcast_lstm, self.forecast_lstm
         for name, param in flatten(e.named_parameters() for e in lstms):
-            if 'weight_ih' in name and IH_XAVIER in self.cfg.weight_init_opts:
+            if 'weight_ih' in name and LSTM_IH_XAVIER in self.cfg.weight_init_opts:
                 nn.init.xavier_uniform_(param)
 
     def forward(

--- a/googlehydrology/utils/config.py
+++ b/googlehydrology/utils/config.py
@@ -564,8 +564,8 @@ class Config(object):
         return self._cfg.get("initial_forget_bias", None)
 
     @property
-    def use_xavier_init(self) -> bool:
-        return self._cfg.get("use_xavier_init", False)
+    def use_advanced_init(self) -> bool:
+        return self._cfg.get("use_advanced_init", False)
 
     @property
     def is_continue_training(self) -> bool:

--- a/googlehydrology/utils/config.py
+++ b/googlehydrology/utils/config.py
@@ -30,7 +30,7 @@ from ruamel.yaml import YAML
 class WeightInitOpt(str, enum.Enum):
     """Opts for the weight_init_opts flag."""
 
-    IH_XAVIER = "ih-xavier"
+    LSTM_IH_XAVIER = "lstm-ih-xavier"
     FC_XAVIER = "fc-xavier"
 
 class Config(object):

--- a/googlehydrology/utils/config.py
+++ b/googlehydrology/utils/config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
 import logging
 import itertools
 import random
@@ -25,6 +26,12 @@ from typing import Any, Optional, Union
 import pandas as pd
 from ruamel.yaml import YAML
 
+@enum.unique
+class WeightInitOpt(str, enum.Enum):
+    """Opts for the weight_init_opts flag."""
+
+    IH_XAVIER = "ih-xavier"
+    FC_XAVIER = "fc-xavier"
 
 class Config(object):
     """Read run configuration from the specified path or dictionary and parse it into a configuration object.
@@ -564,8 +571,11 @@ class Config(object):
         return self._cfg.get("initial_forget_bias", None)
 
     @property
-    def use_advanced_init(self) -> bool:
-        return self._cfg.get("use_advanced_init", False)
+    def weight_init_opts(self) -> set[WeightInitOpt]:
+        res = set(self._as_default_list(self._cfg.get("weight_init_opts", [])))
+        bad_keys = res.difference(e.value for e in WeightInitOpt)
+        assert not bad_keys, f'unsupported weight_init_opts: {bad_keys}'
+        return res
 
     @property
     def is_continue_training(self) -> bool:

--- a/googlehydrology/utils/config.py
+++ b/googlehydrology/utils/config.py
@@ -564,6 +564,10 @@ class Config(object):
         return self._cfg.get("initial_forget_bias", None)
 
     @property
+    def use_xavier_init(self) -> bool:
+        return self._cfg.get("use_xavier_init", False)
+
+    @property
     def is_continue_training(self) -> bool:
         return self._cfg.get("is_continue_training", False)
 


### PR DESCRIPTION
We should test inits that aren't necessarily uniform random or zeros, such as [xavier_uniform_](https://docs.pytorch.org/docs/stable/nn.init.html#torch.nn.init.xavier_uniform_) for ih (input-to-hidden) weights and [orthogonal_](https://docs.pytorch.org/docs/stable/nn.init.html#torch.nn.init.orthogonal_) for hh (hidden to hidden).

NSE seems starting off a bit better, e.g. 10 min train:
<img width="1547" height="812" alt="Screenshot 2025-10-29 at 13 55 46" src="https://github.com/user-attachments/assets/5abaa4b0-eb7c-4314-8555-fbeaf61ff157" />