### PR TITLE
Support features lists as different types

### DIFF
--- a/config/multimet_mean_embedding_forecast_lstm.yml
+++ b/config/multimet_mean_embedding_forecast_lstm.yml
@@ -91,23 +91,29 @@ dataset: multimet
 seq_length: 365
 lead_time: 7
 forecast_inputs:
-- hres_surface_net_solar_radiation
-- hres_surface_net_thermal_radiation
-- hres_surface_pressure
-- hres_temperature_2m
-- hres_total_precipitation
-- graphcast_temperature_2m
-- graphcast_total_precipitation
+  hres:
+    - hres_surface_net_solar_radiation
+    - hres_surface_net_thermal_radiation
+    - hres_surface_pressure
+    - hres_temperature_2m
+    - hres_total_precipitation
+  graphcast:
+    - graphcast_temperature_2m
+    - graphcast_total_precipitation
 hindcast_inputs:
-- hres_surface_net_solar_radiation
-- hres_surface_net_thermal_radiation
-- hres_surface_pressure
-- hres_temperature_2m
-- hres_total_precipitation
-- graphcast_temperature_2m
-- graphcast_total_precipitation
-- imerg_precipitation
-- cpc_precipitation
+  hres:
+    - hres_surface_net_solar_radiation
+    - hres_surface_net_thermal_radiation
+    - hres_surface_pressure
+    - hres_temperature_2m
+    - hres_total_precipitation
+  graphcast:
+    - graphcast_temperature_2m
+    - graphcast_total_precipitation
+  imerg:
+    - imerg_precipitation
+  cpc:
+    - cpc_precipitation
 static_attributes:
 - area
 - p_mean

--- a/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
+++ b/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
@@ -24,7 +24,7 @@ from googlehydrology.modelzoo.fc import FC
 from googlehydrology.modelzoo.head import get_head
 from googlehydrology.utils.config import Config, WeightInitOpt, EmbeddingSpec
 from googlehydrology.utils.lstm_utils import lstm_init
-from googlehydrology.utils.configutils import group_by_prefix
+from googlehydrology.utils.configutils import group_features_list
 
 FC_XAVIER = WeightInitOpt.FC_XAVIER
 
@@ -309,8 +309,8 @@ class ConfigData:
         assert (hindcast_embedding := cfg.hindcast_embedding) is not None
         assert (forecast_embedding := cfg.forecast_embedding) is not None
 
-        hindcast_inputs_grouped = group_by_prefix(cfg.hindcast_inputs)
-        forecast_inputs_grouped = group_by_prefix(cfg.forecast_inputs)
+        hindcast_inputs_grouped = group_features_list(cfg.hindcast_inputs)
+        forecast_inputs_grouped = group_features_list(cfg.forecast_inputs)
         shared_groups = set(hindcast_inputs_grouped) & set(forecast_inputs_grouped)
         for group in shared_groups:
             assert (

--- a/googlehydrology/utils/configutils.py
+++ b/googlehydrology/utils/configutils.py
@@ -68,13 +68,23 @@ def flatten_feature_list(data: list[str] | list[list[str]] | dict[str, list[str]
     return list(data)
 
 
-def group_by_prefix(features: Iterable[str]) -> dict[str, set[str]]:
+def group_features_list(features: list[str] | list[list[str]] | dict[str, list[str]]) -> dict[str, set[str]]:
     """
     Groups list of features according to the prefix of each feature.
-    Assumes the prefix is written with an underscore at the start of the feature name.
+    For lists, assumes the prefix is written with an underscore for the first feature name.
     """
-    result = {}
-    for feature in features:
-        prefix = feature.partition('_')[0]
-        result.setdefault(prefix, set()).add(feature)
-    return result
+    if not features:
+        return {}
+    if isinstance(features, dict):
+        return {key: set(value) for key, value in features.items()}
+    if isinstance(features, list) and isinstance(features[0], list):
+        return {_prefix(sublist[0]): set(sublist) for sublist in features}
+    if isinstance(features, list) and all(isinstance(e, str) for e in features):
+        result = {}
+        for feature in features:
+            result.setdefault(_prefix(feature), set()).add(feature)
+        return result
+    raise ValueError(f"Unsupported type {features}")
+
+def _prefix(feature: str) -> str:
+    return feature.partition('_')[0]

--- a/googlehydrology/utils/configutils.py
+++ b/googlehydrology/utils/configutils.py
@@ -73,6 +73,7 @@ def group_features_list(features: list[str] | list[list[str]] | dict[str, list[s
     Groups list of features according to the prefix of each feature.
     For lists, assumes the prefix is written with an underscore for the first feature name.
     """
+    # TODO (future) :: Simplify types to only dict.
     if not features:
         return {}
     if isinstance(features, dict):

--- a/test/test_configutils.py
+++ b/test/test_configutils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Unit tests for configutils functions. """
-from googlehydrology.utils.configutils import flatten_feature_list, group_by_prefix
+from googlehydrology.utils.configutils import flatten_feature_list, group_features_list
 
 def test_flatten_feature_list_empty_list_input():
     """Tests behavior with an empty list input."""
@@ -60,33 +60,32 @@ def test_flatten_feature_list_list_of_empty_lists():
     expected = []
     assert flatten_feature_list(data) == expected
 
-
-def test_group_by_prefix_normal_case():
+def test_group_features_list_normal_case():
     """Tests a typical case with multiple groups and items."""
     features = ['temp_max', 'temp_min', 'wind_speed', 'wind_dir', 'temp_avg']
     expected = {
         'temp': {'temp_max', 'temp_min', 'temp_avg'},
         'wind': {'wind_speed', 'wind_dir'},
     }
-    assert group_by_prefix(features) == expected
+    assert group_features_list(features) == expected
 
-def test_group_by_prefix_empty_list():
+def test_group_features_list_empty_list():
     """Tests what happens when an empty list is provided."""
-    assert group_by_prefix([]) == {}
+    assert group_features_list([]) == {}
 
-def test_group_by_prefix_single_item():
+def test_group_features_list_single_item():
     """Tests a list with only one item."""
     features = ['pressure_sea']
     expected = {'pressure': {'pressure_sea'}}
-    assert group_by_prefix(features) == expected
+    assert group_features_list(features) == expected
 
-def test_group_by_prefix_all_same_prefix():
+def test_group_features_list_all_same_prefix():
     """Tests when all items share the same prefix."""
     features = ['cloud_high', 'cloud_mid', 'cloud_low']
     expected = {'cloud': {'cloud_high', 'cloud_mid', 'cloud_low'}}
-    assert group_by_prefix(features) == expected
+    assert group_features_list(features) == expected
 
-def test_group_by_prefix_no_underscores():
+def test_group_features_list_no_underscores():
     """Tests features that do not contain an underscore. 
         The entire string should become the prefix."""
     features = ['temperature', 'wind', 'pressure']
@@ -95,10 +94,78 @@ def test_group_by_prefix_no_underscores():
         'wind': {'wind'},
         'pressure': {'pressure'},
     }
-    assert group_by_prefix(features) == expected
+    assert group_features_list(features) == expected
 
-def test_group_by_prefix_multiple_underscores():
+def test_group_features_list_multiple_underscores():
     """Tests that only the first part before the *first* underscore is used."""
     features = ['data_v1_max', 'data_v1_min', 'data_v2_mean']
     expected = {'data': {'data_v1_max', 'data_v1_min', 'data_v2_mean'}}
-    assert group_by_prefix(features) == expected
+    assert group_features_list(features) == expected
+
+def test_group_features_list_nested_list_normal_case():
+    """Tests a typical case with multiple groups and items."""
+    features = [['temp_max', 'temp_min', 'temp_avg'], ['wind_speed', 'wind_dir']]
+    expected = {
+        'temp': {'temp_max', 'temp_min', 'temp_avg'},
+        'wind': {'wind_speed', 'wind_dir'},
+    }
+    assert group_features_list(features) == expected
+
+def test_group_features_list_nested_list_repeating_item():
+    """Tests a nested list with a repeating item."""
+    features = [['pressure_sea', 'pressure_sea']]
+    expected = {'pressure': {'pressure_sea'}}
+    assert group_features_list(features) == expected
+
+def test_group_features_list_nested_list_all_same_prefix():
+    """Tests when all items share the same prefix."""
+    features = [['cloud_high', 'cloud_mid', 'cloud_low']]
+    expected = {'cloud': {'cloud_high', 'cloud_mid', 'cloud_low'}}
+    assert group_features_list(features) == expected
+
+def test_group_features_list_nested_list_no_underscores():
+    """Tests features that do not contain an underscore. 
+        The entire first string should become the prefix."""
+    features = [['temperature', 'wind', 'pressure']]
+    expected = {
+        'temperature': {'temperature', 'wind', 'pressure'},
+    }
+    assert group_features_list(features) == expected
+
+def test_group_features_list_nested_list_multiple_underscores():
+    """Tests that only the first part before the *first* underscore is used."""
+    features = [['data_v1_max', 'data_v1_min', 'data_v2_mean']]
+    expected = {'data': {'data_v1_max', 'data_v1_min', 'data_v2_mean'}}
+    assert group_features_list(features) == expected
+
+def test_group_features_list_dict_normal_case():
+    """Tests a typical case with multiple groups and items."""
+    features = {'temp': ['temp_max', 'temp_min', 'temp_avg'], 'wind': ['wind_speed', 'wind_dir']}
+    expected = {
+        'temp': {'temp_max', 'temp_min', 'temp_avg'},
+        'wind': {'wind_speed', 'wind_dir'},
+    }
+    assert group_features_list(features) == expected
+
+def test_group_features_list_empty_dict():
+    """Tests what happens when an empty dict is provided."""
+    assert group_features_list({}) == {}
+
+def test_group_features_list_dict_repeating_item():
+    """Tests a dict with a repeating item."""
+    features = {'group': ['pressure_sea', 'pressure_sea']}
+    expected = {'group': {'pressure_sea'}}
+    assert group_features_list(features) == expected
+
+def test_group_features_list_dict_all_same_prefix():
+    """Tests when all items share the same prefix."""
+    features = {'cloud': ['cloud_high', 'cloud_mid', 'cloud_low']}
+    expected = {'cloud': {'cloud_high', 'cloud_mid', 'cloud_low'}}
+    assert group_features_list(features) == expected
+
+def test_group_features_list_dict_no_underscores():
+    """Tests features that do not contain an underscore. 
+        The entire string should become the prefix."""
+    features = {'group': ['temperature', 'wind', 'pressure']}
+    expected = {'group': {'temperature', 'wind', 'pressure'}}
+    assert group_features_list(features) == expected


### PR DESCRIPTION
Allow features inputs from config (hindcast, forecast) to be wither list[str], list[list[str]] or dict[str, list[str]]. This provides flexibility for clients to group feature lists by their group names.