### PR TITLE
Address weight torch.load warning.

### DIFF
--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -139,7 +139,9 @@ class BaseTester(object):
         weight_file = self._get_weight_file(epoch)
 
         LOGGER.info(f"Using the model weights from {weight_file}")
-        self.model.load_state_dict(torch.load(weight_file, map_location=self.device))
+        self.model.load_state_dict(
+            torch.load(weight_file, map_location=self.device, weights_only=True)
+        )
 
     def _get_dataset_all(self) -> Dataset:
         """Get dataset for all basin."""

--- a/googlehydrology/training/basetrainer.py
+++ b/googlehydrology/training/basetrainer.py
@@ -164,12 +164,24 @@ class BaseTrainer(object):
 
         if self.cfg.checkpoint_path is not None:
             LOGGER.info(f"Starting training from Checkpoint {self.cfg.checkpoint_path}")
-            self.model.load_state_dict(torch.load(str(self.cfg.checkpoint_path), map_location=self.device))
+            self.model.load_state_dict(
+                torch.load(
+                    str(self.cfg.checkpoint_path),
+                    map_location=self.device,
+                    weights_only=True,
+                )
+            )
         elif self.cfg.checkpoint_path is None and self.cfg.is_finetuning:
             # the default for finetuning is the last model state
             checkpoint_path = [x for x in sorted(list(self.cfg.base_run_dir.glob('model_epoch*.pt')))][-1]
             LOGGER.info(f"Starting training from checkpoint {checkpoint_path}")
-            self.model.load_state_dict(torch.load(str(checkpoint_path), map_location=self.device))
+            self.model.load_state_dict(
+                torch.load(
+                    str(checkpoint_path),
+                    map_location=self.device,
+                    weights_only=True,
+                )
+            )
 
         # Freeze model parts from pre-trained model.
         if self.cfg.is_finetuning:
@@ -311,8 +323,14 @@ class BaseTrainer(object):
         optimizer_path = self.cfg.base_run_dir / f"optimizer_state_epoch{epoch}.pt"
 
         LOGGER.info(f"Continue training from epoch {int(epoch)}")
-        self.model.load_state_dict(torch.load(weight_path, map_location=self.device))
-        self.optimizer.load_state_dict(torch.load(str(optimizer_path), map_location=self.device))
+        self.model.load_state_dict(
+            torch.load(weight_path, map_location=self.device, weights_only=True)
+        )
+        self.optimizer.load_state_dict(
+            torch.load(
+                str(optimizer_path), map_location=self.device, weights_only=True
+            )
+        )
 
     def _save_weights_and_optimizer(self, epoch: int):
         weight_path = self.cfg.run_dir / f"model_epoch{epoch:03d}.pt"


### PR DESCRIPTION
We don't customize torch.save with custom data formats. In a future release those asserts that only weights are loaded will be enabled, so it's better to address the warning and enable it now.

Checked train (and validate), evaluate, continue_training

Warning was
```
[INFO] 17:07:56.838 (tester.py:_load_weights) -- Using the model weights from ~/amarkel/nh-data/runs/mean_embedding_forecast_lstm_0411_163236/model_epoch001.pt
[WARNING] 17:07:56.839 (warnings.py:_showwarnmsg) -- ~/amarkel/flood-forecasting/googlehydrology/evaluation/tester.py:142: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  self.model.load_state_dict(torch.load(weight_file, map_location=self.device))
```