### PR TITLE
Address UnstableSpecificationWarning: use variable strings (Object)

### DIFF
--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -699,7 +699,7 @@ class UncertaintyTester(BaseTester):
 
 def _ensure_unicode_or_bytes_are_strings(ds: xarray.Dataset):
     updates = {
-        name: coord.astype(str)
+        name: coord.astype('O')
         for name, coord in ds.coords.items()
         if coord.dtype.kind in ('U', 'S')
     }


### PR DESCRIPTION
This converts old types of Unicode or Byte String data to the variable length string type, which is better supported in zarr.

While it's possible to use the most modern numpy.dtype.StringDType, it'd require setting up explicitly an encoding dict for the to_zarr call, akin to `encoding = { name: {"dtype": "str"} for name, coord in ds.coords.items() if isinstance(coord.dtype, np.dtypes.StringDType)}`, but it's more complicated. So it's simpler to let the framework assign these automatically.

The warning was:
```
[INFO] 17:07:56.838 (tester.py:_load_weights) -- Using the model weights from ~/amarkel/nh-data/runs/mean_embedding_forecast_lstm_0411_163236/model_epoch001.pt
[WARNING] 17:07:56.839 (warnings.py:_showwarnmsg) -- ~/amarkel/flood-forecasting/googlehydrology/evaluation/tester.py:142: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  self.model.load_state_dict(torch.load(weight_file, map_location=self.device))
```