### PR TITLE
Maximize output zarr compatibility: consolidated=False (addresses ZarrUserWarning)

### DIFF
--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -481,9 +481,9 @@ class BaseTester(object):
             ds = _ensure_unicode_or_bytes_are_strings(ds)
 
             if result_file.exists():
-                ds.to_zarr(result_file, append_dim='basin')
+                ds.to_zarr(result_file, append_dim='basin', consolidated=False)
             else:
-                ds.to_zarr(result_file, mode='w')
+                ds.to_zarr(result_file, mode='w', consolidated=False)
 
         # store all model output in a zarr store
         if (
@@ -503,9 +503,9 @@ class BaseTester(object):
             ds = _ensure_unicode_or_bytes_are_strings(ds)
 
             if result_file.exists():
-                ds.to_zarr(result_file, append_dim='basin')
+                ds.to_zarr(result_file, append_dim='basin', consolidated=False)
             else:
-                ds.to_zarr(result_file, mode='w')
+                ds.to_zarr(result_file, mode='w', consolidated=False)
 
     def _parent_directory_for_results(self, epoch: int | None = None):
         # determine parent directory name and create if needed


### PR DESCRIPTION
https://tutorial.xarray.dev/intermediate/intro-to-zarr.html#consolidated-metadata

It speeds up reading when `True`, however it's not part of the complete standard, so it's available only in Python.

Despite that Python is the use-case, we should have improved compatibility when someone would want to use e.g. C++ to read outputs.

Addresses the warning during inference:
```
[WARNING] 17:54:44.590 (warnings.py:_showwarnmsg) -- ~/amarkel/miniconda3/envs/googlehydrology/lib/python3.12/site-packages/zarr/api/asynchronous.py:244: ZarrUserWarning: Consolidated metadata is currently not part in the Zarr format 3 specification. It may not be supported by other zarr implementations and may change in the future.
```