### PR TITLE
[cmal_deterministic] Make values safe and optimize.

### DIFF
--- a/googlehydrology/utils/cmal_deterministic.py
+++ b/googlehydrology/utils/cmal_deterministic.py
@@ -16,7 +16,7 @@
 
 This method is a deterministic alternative to random sampling CMAL, where there's
 memory constraints on GPU and/or CPU. It takes 10 representative points from the
-predictive dist, and 32 binary search iterations for quantiles. 10 points are
+predictive dist, and searches for quantiles. 10 points are
 9 quantiles from 0.1 to 0.9 and a statistical mean of mixture dist.
 
 When n_samples is low, this algorithm should serve as a better approximation.
@@ -44,51 +44,35 @@ def generate_predictions(
         Summary dist where last dim has the dist mean followed by calculated quantiles.
     """
     with torch.cuda.amp.autocast(enabled=torch.cuda.is_available()):
-        # https://www.tandfonline.com/doi/abs/10.1080/03610920500199018
-        tau_c = 1 - tau
-        means = mu + b * tau * tau_c * (1 / tau**2 - 1 / tau_c**2)
-        mean = torch.unsqueeze(torch.sum(pi * means, dim=-1), dim=-1)
+        # https://www.tandfonline.com/doi/abs/10.1080/03610920500199018 (modified)
         quantiles = _mixture_params_to_quantiles(mu, b, tau, pi)
+
+        tau = torch.clamp(tau, min=1e-6, max=1.0 - 1e-6)
+        means = mu + b * (1 - 2 * tau) / (tau * (1 - tau))
+        mean = torch.unsqueeze(torch.sum(pi * means, dim=-1), dim=-1)
         # Returned tensor, in last dimension, has the distribution mean followed by
         # the calculated quantiles.
         return torch.concat([mean, quantiles], dim=-1)
 
 
-def _cdf(
+def _cdf_and_pdf(
     x: torch.Tensor, mu: torch.Tensor, b: torch.Tensor, tau: torch.Tensor
-) -> torch.Tensor:
-    """Computes the Cumulative Distribution Function (CDF) at x for the dists."""
-    tau_c = 1 - tau
-    return torch.where(
-        x <= mu,
-        tau * torch.exp(tau_c * (x - mu) / b),
-        1 - tau_c * torch.exp(-tau * (x - mu) / b),
-    )
-
-
-def _pdf(
-    x: torch.Tensor, mu: torch.Tensor, b: torch.Tensor, tau: torch.Tensor
-) -> torch.Tensor:
-    """Computes the Probability Density Function (PDF) at x, the derivative of CDF."""
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Computes the CDF and PDF (CDF') at x for the dists."""
     tau_c = 1.0 - tau
-    indicator = (x > mu).float()
-    main_term = tau * tau_c / b  # scaled exp func
-    exp_term = torch.exp(
-        -indicator * tau * (x - mu) / b
-        - (1.0 - indicator) * tau_c * (mu - x) / b
+    indicator = x > mu
+    z = (x - mu) / b
+
+    cdf = torch.where(
+        indicator, 1 - tau_c * torch.exp(-tau * z), tau * torch.exp(z * tau_c)
     )
-    return main_term * exp_term
 
+    indicator = indicator.float()
+    pdf = (tau * tau_c / b) * torch.exp(
+        -indicator * tau * z - (1.0 - indicator) * tau_c * (-z)
+    )
 
-def _mixture_pdf(
-    x: torch.Tensor,
-    mu: torch.Tensor,
-    b: torch.Tensor,
-    tau: torch.Tensor,
-    pi: torch.Tensor,
-) -> torch.Tensor:
-    """Calculates the PDF of the mixture distribution."""
-    return torch.sum(_pdf(x, mu, b, tau) * pi, dim=2, keepdim=True)
+    return cdf, pdf
 
 
 def _ppf(
@@ -106,18 +90,21 @@ def _ppf(
     )
 
 
-def _mixture_cdf(
+def _mixture_cdf_and_pdf(
     x: torch.Tensor,
     mu: torch.Tensor,
     b: torch.Tensor,
     tau: torch.Tensor,
     pi: torch.Tensor,
-) -> torch.Tensor:
-    """Returns the CDF of the mixture dist.
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Returns the CDF and PDF of the mixture dist.
 
-    The CDF is the weighted sum of the CDFs of the components.
+    The CDF is the weighted sum of the CDFs and PDFs of the components.
     """
-    return torch.sum(_cdf(x, mu, b, tau) * pi, dim=2, keepdim=True)
+    cdf, pdf = _cdf_and_pdf(x, mu, b, tau)
+    mixture_cdf = torch.sum(cdf * pi, dim=2, keepdim=True)
+    mixture_pdf = torch.sum(pdf * pi, dim=2, keepdim=True)
+    return mixture_cdf, mixture_pdf
 
 
 def _search_quantile(
@@ -126,7 +113,9 @@ def _search_quantile(
     b: torch.Tensor,
     tau: torch.Tensor,
     pi: torch.Tensor,
-    iterations: int = 8,
+    iterations: int = 10,
+    epsilon: float = 1e-6,  # to avoid zero values
+    frac_confine: float = 0.8,  # to avoid overshooting
 ) -> torch.Tensor:
     """Search for the quantile of a mixture dist via newton-raphson (NR).
 
@@ -135,15 +124,15 @@ def _search_quantile(
     So f(x)  = mixture_cdf(x) - quantile
        f'(x) = CDF(x) dx = PDF(x)
     """
-    k = torch.mean(
-        _ppf(quantile, mu, b, tau), dim=2, keepdim=True
-    )  # initial point
-    epsilon = 1e-6  # to avoid zero values
+    ppfs = _ppf(quantile, mu, b, tau)
+    low = frac_confine * torch.min(ppfs, dim=2, keepdim=True).values
+    high = frac_confine * torch.max(ppfs, dim=2, keepdim=True).values
 
+    k = torch.mean(ppfs, dim=2, keepdim=True)
     for _ in range(iterations):
-        cdf_val = _mixture_cdf(k, mu, b, tau, pi)
-        pdf_val = _mixture_pdf(k, mu, b, tau, pi)
+        cdf_val, pdf_val = _mixture_cdf_and_pdf(k, mu, b, tau, pi)
         k = k - (cdf_val - quantile) / (pdf_val + epsilon)
+        k = torch.clamp(k, low, high)
 
     return torch.squeeze(k, dim=2)
 
@@ -165,6 +154,4 @@ def _mixture_params_to_quantiles(
         device=mu.device,
         dtype=mu.dtype,
     )
-    return _search_quantile(
-        quantiles.view(1, 1, 1, -1), mu_exp, b_exp, tau_exp, pi_exp
-    )
+    return _search_quantile(quantiles.view(1, 1, 1, -1), mu_exp, b_exp, tau_exp, pi_exp)


### PR DESCRIPTION
* Make values safe via clamping `tau` to not be exactly 0 or 1 as well as clamping `k` in search quantile to the ppf component range.
* Optimize the `means` expression. Tau can't be zero nor 1 - tau. So if we: take common terms from the two terms `(1/t**2-1/(1-t)**2)` then we see a `a**2-b**2=(a-b)(a+b)` pattern where that (a+b) part becomes just 1 and we can simplify the resulting `(1-tau)/(1-tau)**2` expression. So we're left with (1-2tau)/t/(1-tau).
* Optimize the cdf and pdf calculation into one, there's several sub expressions that are the same exactly.
* Noting additional optimizations are possible like the indicator (`x > mu`) and the subtraction `x - mu` but that could be for future work and a smaller impact change. cmal deterministic is an approximation anyway for CPU or memory constraints, and IMHO it's optimized sufficiently.