### PR TITLE
Cache open_zarr's metadata-only returned objects.

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -767,6 +767,7 @@ def _convert_to_tensor(
     raise ValueError(f'Unrecognized data type: {type(value)}')
 
 
+@functools.cache
 def _open_zarr(path: Path) -> xr.Dataset:
     path = str(path).replace('gs:/', 'gs://')
     return xr.open_zarr(store=path, chunks='auto', decode_timedelta=True)


### PR DESCRIPTION
When the object is the same, dask can optimize loading data from disk once. The object itself is only metadata info.