### PR TITLE
[optimize] on valid/test, reuse `model(data)` (`forward`'s result)

### DIFF
--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -899,7 +899,7 @@ class UncertaintyTester(BaseTester):
         LOGGER.debug('getting model losses')
         _, all_losses = self.loss_obj(outputs, data)
         LOGGER.debug('getting model predictions (sample)')
-        predictions = model.sample(data, self.cfg.n_samples)
+        predictions = model.sample(data, self.cfg.n_samples, outputs=outputs)
         LOGGER.debug('getting model eval')
         model.eval()
         return predictions, {k: v.item() for k, v in all_losses.items()}

--- a/googlehydrology/modelzoo/basemodel.py
+++ b/googlehydrology/modelzoo/basemodel.py
@@ -49,7 +49,11 @@ class BaseModel(nn.Module):
         )
 
     def sample(
-        self, data: dict[str, torch.Tensor], n_samples: int
+        self,
+        data: dict[str, torch.Tensor],
+        n_samples: int,
+        *,
+        outputs: dict[str, torch.Tensor] | None = None,
     ) -> dict[str, torch.Tensor]:
         """Provides point prediction samples from a probabilistic model.
 
@@ -64,13 +68,17 @@ class BaseModel(nn.Module):
             Dictionary, containing input features as key-value pairs.
         n_samples : int
             Number of point predictions that ought ot be sampled form the model.
+        outputs, optional
+            Model forward result
 
         Returns
         -------
         dict[str, torch.Tensor]
             Sampled point predictions
         """
-        return sample_pointpredictions(self, data, n_samples, self._scaler)
+        return sample_pointpredictions(
+            self, data, n_samples, self._scaler, outputs=outputs
+        )
 
     def forward(
         self, data: dict[str, torch.Tensor | dict[str, torch.Tensor]]


### PR DESCRIPTION
For 7500 samples for cmal:
* CPU: 12s/it -> 7s/it
* GPU: 5s/it -> 4s/it

20% improvement on GPU; 40% on CPU - so it's worth it.

---

cmal_deterministic:

* GPU: 2.6s/it -> 2.2s/it