### PR TITLE
[optimize] Detach scaler check zero and save from the graph

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -253,9 +253,14 @@ class Multimet(Dataset):
         LOGGER.debug('materialize data (compute)')
         # We explicitly keep the self.scaler.scaler computation since trainer uses it directly
         # create sample index does a compute on the data. We compute here prior to avoid recompute.
-        self._dataset, self.scaler.scaler = dask.compute(
-            self._dataset, self.scaler.scaler
+        self._dataset, self.scaler.scaler, self.scaler.is_zero = dask.compute(
+            self._dataset, self.scaler.scaler, self.scaler.is_zero
         )
+
+        LOGGER.debug('scaler check zero scale')
+        self.scaler.check_zero_scale()
+        LOGGER.debug('scaler save')
+        self.scaler.save()
 
         # Create sample index lookup table for `__getitem__`.
         LOGGER.debug('create sample index')

--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -253,8 +253,8 @@ class Multimet(Dataset):
         LOGGER.debug('materialize data (compute)')
         # We explicitly keep the self.scaler.scaler computation since trainer uses it directly
         # create sample index does a compute on the data. We compute here prior to avoid recompute.
-        self._dataset, self.scaler.scaler, self.scaler.is_zero = dask.compute(
-            self._dataset, self.scaler.scaler, self.scaler.is_zero
+        self._dataset, self.scaler.scaler = dask.compute(
+            self._dataset, self.scaler.scaler
         )
 
         LOGGER.debug('scaler check zero scale')

--- a/googlehydrology/datautils/scaler.py
+++ b/googlehydrology/datautils/scaler.py
@@ -166,8 +166,7 @@ class Scaler:
             raise ValueError(
                 'You are trying to save a scaler that has not been computed.'
             )
-        chunks = self.scaler.chunks
-        assert not chunks, f'`scaler` needs to be computed yet has {chunks=}'
+        _assert_computed(self.scaler)
 
         os.makedirs(self.scaler_dir, exist_ok=True)
         scaler_file = self.scaler_dir / SCALER_FILE_NAME
@@ -175,8 +174,7 @@ class Scaler:
             self.scaler.to_netcdf(f)
 
     def check_zero_scale(self):
-        chunks = self.scaler.chunks
-        assert not chunks, f'`scaler` needs to be computed yet has {chunks=}'
+        _assert_computed(self.scaler)
 
         scales_to_check = self.scaler.sel(parameter=['scale', 'std'])
         is_zero = (scales_to_check == 0).any('parameter').to_dataarray()
@@ -267,3 +265,8 @@ def is_any_lazy(dataset: xr.Dataset) -> bool:
         isinstance(var.data, dask.array.Array)
         for var in dataset.data_vars.values()
     )
+
+def _assert_computed(da: xr.DataArray | xr.Dataset | None):
+    assert da is not None
+    chunks = da.chunks
+    assert not chunks, f'`scaler` needs to be computed yet has {chunks=}'

--- a/googlehydrology/datautils/scaler.py
+++ b/googlehydrology/datautils/scaler.py
@@ -169,6 +169,9 @@ class Scaler:
             raise ValueError(
                 'You are trying to save a scaler that has not been computed.'
             )
+        chunks = self.scaler.chunks
+        assert not chunks, f'`scaler` needs to be computed yet has {chunks=}'
+
         os.makedirs(self.scaler_dir, exist_ok=True)
         scaler_file = self.scaler_dir / SCALER_FILE_NAME
         with open(scaler_file, 'wb') as f:
@@ -179,6 +182,9 @@ class Scaler:
         self.is_zero = (scales_to_check == 0).any('parameter').to_dataarray()
 
     def check_zero_scale(self):
+        chunks = self.is_zero.chunks
+        assert not chunks, f'`is_zero` needs to be computed yet has {chunks=}'
+
         features = self.is_zero['variable'][self.is_zero]
         if any(features):
             raise ValueError(

--- a/test/test_scaler.py
+++ b/test/test_scaler.py
@@ -322,23 +322,24 @@ def test_scaler_calculate_custom_normalization(
     )
 
 
-# --- MODIFIED TEST for `_check_zero_scale` being called by `calculate` ---
+# --- MODIFIED TEST for `check_zero_scale` being called by `calculate` ---
 def test_scaler_scale_raises_error_for_zero_scale(
     tmp_scaler_dir, sample_dataset_with_constant_var
 ):
     # `constant_val` has a standard deviation of 0.0.
-    # The scale method should now raise a ValueError due to _check_zero_scale().
+    # The scale method should now raise a ValueError due to check_zero_scale().
     scaler = Scaler(
         scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None
     )
     scaler.calculate(sample_dataset_with_constant_var)
+    (scaler.is_zero,) = dask.compute(scaler.is_zero)
     with pytest.raises(
         ValueError, match='Zero scale values found for features:'
     ):
-        dask.compute(scaler.scaler)
+        scaler.check_zero_scale()
 
 
-# --- NEW TEST: Direct test of _check_zero_scale ---
+# --- NEW TEST: Direct test of check_zero_scale ---
 def test_check_zero_scale_method_raises_error(tmp_scaler_dir):
     scaler = Scaler(
         scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None
@@ -354,10 +355,12 @@ def test_check_zero_scale_method_raises_error(tmp_scaler_dir):
         },
         coords={'parameter': ['center', 'scale', 'mean', 'std']},
     )
+    scaler._prepare_check_zero_scale_input()
+    (scaler.is_zero,) = dask.compute(scaler.is_zero)
     with pytest.raises(
         ValueError, match='Zero scale values found for features:'
     ):
-        scaler._check_zero_scale()
+        scaler.check_zero_scale()
 
 
 def test_check_zero_scale_method_no_error_for_nonzero(tmp_scaler_dir):
@@ -372,59 +375,17 @@ def test_check_zero_scale_method_no_error_for_nonzero(tmp_scaler_dir):
         },
         coords={'parameter': ['center', 'scale', 'mean', 'std']},
     )
+    scaler._prepare_check_zero_scale_input()
     # Should not raise an error
     try:
-        scaler._check_zero_scale()
+        scaler.check_zero_scale()
     except ValueError:
         pytest.fail(
-            '`_check_zero_scale` raised ValueError unexpectedly for non-zero scale values.'
+            '`check_zero_scale` raised ValueError unexpectedly for non-zero scale values.'
         )
 
 
 # --- Test Scaler.scale ---
-
-
-def test_scaler_calculate_binds_save_when_calculated(sample_dataset_basic):
-    calls = []
-
-    def fake(*args, **kwargs):
-        calls.append(True)
-
-    with patch.object(scaler, '_save', side_effect=fake):
-        scaler_instance_calculated = Scaler(
-            scaler_dir=tmp_scaler_dir,
-            calculate_scaler=True,
-            dataset=sample_dataset_basic,
-        )
-
-        assert calls == []
-
-        dask.compute(scaler_instance_calculated.scaler)
-
-    assert calls == [True]
-
-
-def test_scaler_calculate_doesnt_bind_save_when_not_calculated(
-    tmp_scaler_dir, scaler_instance_calculated, sample_dataset_basic
-):
-    scaler_instance_calculated.save()
-    scaler_file_path = tmp_scaler_dir / SCALER_FILE_NAME
-    assert scaler_file_path.exists()
-
-    calls = []
-
-    def fake():
-        calls.append(True)
-
-    with patch.object(scaler, '_save', side_effect=fake):
-        loaded_scaler = Scaler(
-            scaler_dir=tmp_scaler_dir, calculate_scaler=False, dataset=None
-        )
-        loaded_scaler.scale(sample_dataset_basic)
-
-        dask.compute(loaded_scaler.scaler)
-
-    assert calls == []
 
 
 def test_scaler_scale_basic_functionality(
@@ -550,6 +511,9 @@ def test_scaler_unscale_raises_error_for_missing_features(
 def test_scaler_save_and_load(
     tmp_scaler_dir, scaler_instance_calculated, sample_dataset_basic
 ):
+    scaler_instance_calculated.scaler = (
+        scaler_instance_calculated.scaler.compute()
+    )
     scaler_instance_calculated.save()
     scaler_file_path = tmp_scaler_dir / SCALER_FILE_NAME
     assert scaler_file_path.exists()
@@ -588,7 +552,7 @@ def test_scaler_save_raises_error_if_not_calculated(tmp_scaler_dir):
         scaler.save()
 
 
-# --- NEW TESTS: `_check_zero_scale` interaction with `load` ---
+# --- NEW TESTS: `check_zero_scale` interaction with `load` ---
 
 
 def test_scaler_load_from_file_raises_error_for_zero_scale(tmp_scaler_dir):

--- a/test/test_scaler.py
+++ b/test/test_scaler.py
@@ -332,7 +332,7 @@ def test_scaler_scale_raises_error_for_zero_scale(
         scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None
     )
     scaler.calculate(sample_dataset_with_constant_var)
-    (scaler.is_zero,) = dask.compute(scaler.is_zero)
+    scaler.scaler = scaler.scaler.compute()
     with pytest.raises(
         ValueError, match='Zero scale values found for features:'
     ):
@@ -355,8 +355,6 @@ def test_check_zero_scale_method_raises_error(tmp_scaler_dir):
         },
         coords={'parameter': ['center', 'scale', 'mean', 'std']},
     )
-    scaler._prepare_check_zero_scale_input()
-    (scaler.is_zero,) = dask.compute(scaler.is_zero)
     with pytest.raises(
         ValueError, match='Zero scale values found for features:'
     ):
@@ -375,7 +373,6 @@ def test_check_zero_scale_method_no_error_for_nonzero(tmp_scaler_dir):
         },
         coords={'parameter': ['center', 'scale', 'mean', 'std']},
     )
-    scaler._prepare_check_zero_scale_input()
     # Should not raise an error
     try:
         scaler.check_zero_scale()


### PR DESCRIPTION
Dask needs to serialize the parent subgraph upwards to send args to Delayed function, even if the leaf node is very small.

So, we need to validate not as part of dask's computation graph. Made computation a part of the main compute() so it's efficient.

Runtime now is practically immediate, e.g. for 3000 basins over 40yrs: 0.00039s instead of 5.25m (~800,000x faster)

Another option may be to make a division by zero inherent error when a scale is zero, but it won't be descriptive and confusing, and it would need to be exposed to multimet's compute() as well regardless.