### PR TITLE
Allow disabling disk swap for workers.

### DIFF
--- a/config/multimet_mean_embedding_forecast_lstm.yml
+++ b/config/multimet_mean_embedding_forecast_lstm.yml
@@ -53,6 +53,7 @@ weight_init_opts:
 cache:
   enabled: False
   byte_limit: 2000000000  # in GB
+use_swap_memory:
 
 # --- Dataset Parameters --------------------------------------------------------
 

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -62,6 +62,8 @@ General experiment configurations
    in an opportunistic cache:
    Key ``enabled`` (``bool``): Default `False`.
    Key ``byte_limit`` (``int``): Byte limit to use. Default 2GB.
+-  ``use_swap_memory``: whether to enable ``distributed.p2p.storage.disk`` explicitly.
+   None-value results in ``dask``'s default.
 
 .. code-block::
 

--- a/googlehydrology/run.py
+++ b/googlehydrology/run.py
@@ -88,14 +88,14 @@ def _main():
 
     torch.autograd.set_detect_anomaly(config.detect_anomaly)
 
-    dask.config.set(
-        {
-            'distributed.p2p.storage.disk': config.use_swap_memory,
-            'num_workers': os.cpu_count(),
-            'scheduler': 'threads',
-            'shuffle': 'p2p',
-        }
-    )
+    dask_config = {
+        'num_workers': os.cpu_count(),
+        'scheduler': 'threads',
+        'shuffle': 'p2p',
+    }
+    if config.use_swap_memory is not None:
+        dask_config['distributed.p2p.storage.disk'] = config.use_swap_memory
+    dask.config.set(dask_config)
 
     if config.cache.enabled:
         dask.cache.Cache(cachey.Cache(config.cache.byte_limit)).register()

--- a/googlehydrology/run.py
+++ b/googlehydrology/run.py
@@ -90,6 +90,7 @@ def _main():
 
     dask.config.set(
         {
+            'distributed.p2p.storage.disk': False,
             'num_workers': os.cpu_count(),
             'scheduler': 'threads',
             'shuffle': 'p2p',

--- a/googlehydrology/run.py
+++ b/googlehydrology/run.py
@@ -90,7 +90,7 @@ def _main():
 
     dask.config.set(
         {
-            'distributed.p2p.storage.disk': False,
+            'distributed.p2p.storage.disk': config.use_swap_memory,
             'num_workers': os.cpu_count(),
             'scheduler': 'threads',
             'shuffle': 'p2p',

--- a/googlehydrology/utils/config.py
+++ b/googlehydrology/utils/config.py
@@ -864,6 +864,10 @@ class Config(object):
         return self._cfg.get('per_basin_validation_periods_file', None)
 
     @property
+    def use_swap_memory(self) -> bool | None:
+        return self._cfg.get('use_swap_memory', None)
+
+    @property
     def predict_last_n(self) -> int | dict[str, int]:
         return self._get_value_verbose('predict_last_n')
 


### PR DESCRIPTION
If we want memory laziness etc, it should be via the OS +/ our lazy solution or other solution such as loading only the relevant dataset's subset into memory.