### PR TITLE
[optimize] add load_target_features_parallel_processes

### DIFF
--- a/config/multimet_mean_embedding_forecast_lstm.yml
+++ b/config/multimet_mean_embedding_forecast_lstm.yml
@@ -54,6 +54,7 @@ cache:
   enabled: False
   byte_limit: 2000000000  # in GB
 use_swap_memory:
+load_target_features_parallel_processes:
 
 # --- Dataset Parameters --------------------------------------------------------
 

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -64,6 +64,9 @@ General experiment configurations
    Key ``byte_limit`` (``int``): Byte limit to use. Default 2GB.
 -  ``use_swap_memory``: whether to enable ``distributed.p2p.storage.disk`` explicitly.
    None-value results in ``dask``'s default.
+-  ``load_target_features_parallel_processes``: number of processes to use to load target
+   features' netcdf files in parallel. When smaller than 2, no processes are used. The
+   processes are entirely new processes and don't replicate the main program's memory.
 
 .. code-block::
 

--- a/googlehydrology/datasetzoo/mfdata_loader.py
+++ b/googlehydrology/datasetzoo/mfdata_loader.py
@@ -1,0 +1,42 @@
+"""Load basin data (mfdataset) and output its pickle serialization to stdout."""
+
+import pickle
+import sys
+from pathlib import Path
+
+from absl import app, flags
+
+from googlehydrology.datasetzoo.caravan import load_caravan_timeseries_together
+
+DATA_DIR = flags.DEFINE_string(
+    'data_dir',
+    default=None,
+    help='Path to the root directory of Caravan.',
+    required=True,
+)
+
+BASINS = flags.DEFINE_list(
+    'basins',
+    default=None,
+    help='List of basin ids to load.',
+    required=True,
+)
+
+TARGET_FEATURES = flags.DEFINE_list(
+    'target_features',
+    default=None,
+    help='Target variables to select.',
+    required=True,
+)
+
+
+def main(unused_argv):
+    dataset = load_caravan_timeseries_together(
+        Path(DATA_DIR.value), BASINS.value, TARGET_FEATURES.value
+    )
+    serialized = pickle.dumps(dataset)
+    sys.stdout.buffer.write(serialized)
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/googlehydrology/utils/config.py
+++ b/googlehydrology/utils/config.py
@@ -868,6 +868,12 @@ class Config(object):
         return self._cfg.get('use_swap_memory', None)
 
     @property
+    def load_target_features_parallel_processes(self) -> int:
+        return max(
+            1, self._cfg.get('load_target_features_parallel_processes') or 1
+        )
+
+    @property
     def predict_last_n(self) -> int | dict[str, int]:
         return self._get_value_verbose('predict_last_n')
 


### PR DESCRIPTION
Add option to load target features' metadata in parallel processes (that don't duplicate the entire program's memory).

I validated that for both camels (671) and camels_gauges (16k) basins, the output dataset is the same (`.identical()`).

Performance gain is ~75% less time spent on target features' loading during init.

---

Performance gain:

For all basins (camel_gauges.txt), chunking by 500 basins per process, and

```
train_end_date: 31/12/2020
train_start_date: 01/01/2016
validation_end_date: 31/12/2025
validation_start_date: 01/01/2021
```

on cloudtop,

train ds load target features takes 155s instead of 470s.

valid ds load target features takes 91s instead of 486s.

So 1-(155+91)/(470+486) is 74.3% speedup for target features loading.