### PR TITLE
Added CSV readers for inputs and targets.

### DIFF
--- a/googlehydrology/utils/config.py
+++ b/googlehydrology/utils/config.py
@@ -712,6 +712,10 @@ class Config(object):
         return self._cfg.get('learning_rate_epochs_drop', 0)
 
     @property
+    def load_as_csv(self) -> bool:
+        return self._cfg.get('load_as_csv', False)
+        
+    @property
     def log_interval(self) -> int:
         return self._cfg.get('log_interval', 10)
 


### PR DESCRIPTION
Added support for reading from CSV files for inputs and targets, both hindcasts and forecasts. Hindcast and target data are loaded in standard Caravan CSV format, and special format for forecast data was established.

This commit introduces a new config argument to instruct the dataloader to load from CSV files, which defaults to False (read from Zarr). The CSV loaders are not optimized and should not be used for large datasets. Future work will likely be necessary to prevent the user from selecting this option for large datasets.