### PR TITLE
Force all attributes to be loaded as float32.

### DIFF
--- a/googlehydrology/datasetzoo/caravan.py
+++ b/googlehydrology/datasetzoo/caravan.py
@@ -119,8 +119,7 @@ def load_caravan_attributes(
         # Subset to only the requested basins.
         ds = ds.sel(basin=basins)
 
-    ds = ds.astype(np.float32)
-    return ds
+    return ds.astype(np.float32)
 
 
 def load_csvs_as_ds(basin_to_path: dict[str, Path]) -> xarray.Dataset:

--- a/googlehydrology/datasetzoo/caravan.py
+++ b/googlehydrology/datasetzoo/caravan.py
@@ -119,6 +119,7 @@ def load_caravan_attributes(
         # Subset to only the requested basins.
         ds = ds.sel(basin=basins)
 
+    ds = ds.astype(np.float32)
     return ds
 
 


### PR DESCRIPTION
Converts all caravan attributes to float32 before passing to the dataloader.