### PR TITLE
Setup CUDA 12.4 and explicitly setup versions to align with it.

### DIFF
--- a/environments/conda.yml
+++ b/environments/conda.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # How to install:
-# conda env create -f environments/cuda.yml
+# conda env create -f environments/conda.yml
 
 name: googlehydrology
 channels:  # Order matters

--- a/environments/conda.yml
+++ b/environments/conda.yml
@@ -13,18 +13,20 @@
 # limitations under the License.
 
 # How to install:
-# conda env create -f environments/environment_cuda11_8.yml
+# conda env create -f environments/cuda.yml
 
 name: googlehydrology
-channels:
+channels:  # Order matters
   - pytorch
   - nvidia
   - conda-forge
-  - defaults  # Keep last
+  - defaults
 dependencies:
   - absl-py
   - bokeh
   - cachey
+  - cuda-toolkit 
+  - cuda-version=12.4
   - dask
   - gcsfs
   - gh
@@ -42,12 +44,11 @@ dependencies:
   - parso
   - pydantic
   - pytest
-  - pytest
   - pytest-cov
   - pytest-xdist
   - python=3.12
   - pytorch
-  - pytorch-cuda=11.8
+  - pytorch-cuda=12.4
   - ruamel.yaml
   - ruff
   - scipy


### PR DESCRIPTION
1. Cuda 11.8 has been deprecated.
2. The driver NVIDIA-SMI version 550 that supports 11.8 supports 12.4 (`$ nvidia-smi`).
3. 11.8 results in using old deprecated libraries (numpy 1.x instead of 2.x, dask, xarray, etc).

So, upgrading and explicitly setting everything to comply with 12.4 is fine both in compatibility and correctness (version consistency). Also it's better for maintenance since 11.8 is already old and using it ensues with using old versions of core libraries.

Otherwise, running the various tools on the terminal to assess the cuda version, we get different versions. We use pytorch for cuda 11.8 but we use (the installed version) cuda 12.9-3 yet versions from CLIs report 11.8 and 12.4 being used also at the same time.

This must be fixed to ensure the library works henceforth without e.g. segmentation faults due to multiple versions of cuda being used in different contexts once versions start differing in breaking ways.

---

Tested on both CPU and GPU machines (train+valid, infer/test).

---

Testers should delete their env (`conda env remove -n googlehydrology`) and then install again:
```
conda env create -f environments/conda.yml && pip install -e .
```