### PR TITLE
Update existing unit tests

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -103,6 +103,8 @@ class Multimet(Dataset):
         # Feature lists by type.
         self._static_features = cfg.static_attributes
         self._target_features = cfg.target_variables
+        if not cfg.hindcast_inputs:
+            raise ValueError('hindcast_inputs must be supplied.')
         self._forecast_features = flatten_feature_list(cfg.forecast_inputs)
         self._hindcast_features = flatten_feature_list(cfg.hindcast_inputs)
         self._union_mapping = cfg.union_mapping

--- a/test/test_config_runs.py
+++ b/test/test_config_runs.py
@@ -90,9 +90,9 @@ def _check_results(config: Config, basin: str, discharge: pd.Series = None):
     )
 
     if discharge is None:
-        discharge = caravan.load_caravan_timeseries(
-            config.data_dir, basin
-        ).to_dataframe()[config.target_variables]
+        discharge = caravan.load_caravan_timeseries_together(
+            config.data_dir, basin, config.target_variables, csv=False
+        ).to_dataframe()
 
     if hasattr(config, 'lead_time'):
         results = results.isel(time_step=0).squeeze()

--- a/test/test_config_runs.py
+++ b/test/test_config_runs.py
@@ -60,8 +60,11 @@ def test_forecast_daily_regression(
         [[nan_basin], nan_dates], 
         names=['basin', 'date']
     )
-    nan_discharge = pd.Series(
-        float('nan'), index=index)
+    nan_discharge = pd.DataFrame(
+        data=float('nan'), 
+        index=index, 
+        columns=['streamflow']
+    )
     _check_results(config, nan_basin, nan_discharge)  # No valid data.
     _check_results(config, 'lamah_1145')
     _check_results(config, 'hysets_01075000')
@@ -105,12 +108,12 @@ def _check_results(config: Config, basin: str, discharge: pd.Series = None):
         results = results.isel(time_step=-1)
 
     results_array = results[f'{config.target_variables[0]}_obs'].values
+    idx = pd.IndexSlice
     try:
-        idx = pd.IndexSlice
         discharge_slice = discharge.loc[idx[basin, test_start_date:test_end_date], 'streamflow']
-        discharge_array = discharge_slice.values
     except:
         import pdb; pdb.set_trace()
+    discharge_array = discharge_slice.values
 
     assert discharge_array == approx(results_array, nan_ok=True)
 

--- a/test/test_config_runs.py
+++ b/test/test_config_runs.py
@@ -54,10 +54,15 @@ def test_forecast_daily_regression(
     start_training(config)
     start_evaluation(cfg=config, run_dir=config.run_dir, epoch=1, period='test')
 
-    nan_discharge = pd.Series(
-        float('nan'), index=pd.date_range(*get_test_start_end_dates(config))
+    nan_basin = 'camelsaus_102101A'
+    nan_dates = pd.date_range(*get_test_start_end_dates(config))
+    index = pd.MultiIndex.from_product(
+        [[nan_basin], nan_dates], 
+        names=['basin', 'date']
     )
-    _check_results(config, 'camelsaus_102101A', nan_discharge)  # No valid data.
+    nan_discharge = pd.Series(
+        float('nan'), index=index)
+    _check_results(config, nan_basin, nan_discharge)  # No valid data.
     _check_results(config, 'lamah_1145')
     _check_results(config, 'hysets_01075000')
 
@@ -91,7 +96,7 @@ def _check_results(config: Config, basin: str, discharge: pd.Series = None):
 
     if discharge is None:
         discharge = caravan.load_caravan_timeseries_together(
-            config.data_dir, basin, config.target_variables, csv=False
+            config.data_dir, [basin], config.target_variables, csv=False
         ).to_dataframe()
 
     if hasattr(config, 'lead_time'):
@@ -100,9 +105,13 @@ def _check_results(config: Config, basin: str, discharge: pd.Series = None):
         results = results.isel(time_step=-1)
 
     results_array = results[f'{config.target_variables[0]}_obs'].values
-    discharge_array = np.array(
-        [v.item() for v in discharge.loc[test_start_date:test_end_date].values]
-    )
+    try:
+        idx = pd.IndexSlice
+        discharge_slice = discharge.loc[idx[basin, test_start_date:test_end_date], 'streamflow']
+        discharge_array = discharge_slice.values
+    except:
+        import pdb; pdb.set_trace()
+
     assert discharge_array == approx(results_array, nan_ok=True)
 
     # CAMELS forcings have no NaNs, so there should be no NaN predictions

--- a/test/test_config_runs.py
+++ b/test/test_config_runs.py
@@ -109,10 +109,7 @@ def _check_results(config: Config, basin: str, discharge: pd.Series = None):
 
     results_array = results[f'{config.target_variables[0]}_obs'].values
     idx = pd.IndexSlice
-    try:
-        discharge_slice = discharge.loc[idx[basin, test_start_date:test_end_date], 'streamflow']
-    except:
-        import pdb; pdb.set_trace()
+    discharge_slice = discharge.loc[idx[basin, test_start_date:test_end_date], 'streamflow']
     discharge_array = discharge_slice.values
 
     assert discharge_array == approx(results_array, nan_ok=True)

--- a/test/test_configs/forecast.test.yml
+++ b/test/test_configs/forecast.test.yml
@@ -34,7 +34,6 @@ device: cpu
 # --- Validation configuration ---------------------------------------------------------------------
 validate_every: 1
 validate_n_random_basins: 4
-cache_validation_data: True
 metrics:
   - NSE
   - KGE
@@ -68,11 +67,6 @@ dynamics_embedding:
     - 2
   activation: tanh
   dropout: 0.0
-forecast_network:
-  activation: tanh
-  dropout: 0.4
-  hiddens:
-  - 10
 
 # --- Training configuration -----------------------------------------------------------------------
 optimizer: Adam

--- a/test/test_multimet.py
+++ b/test/test_multimet.py
@@ -410,7 +410,7 @@ def test_forecast_dataset_init_forecast_hindcast_mismatch_error(
     )
     with pytest.raises(
         ValueError,
-        match='`hindcast_inputs` must be supplied.',
+        match='hindcast_inputs must be supplied.',
     ):
         Multimet(cfg=cfg, is_train=True, period='train')
 
@@ -419,7 +419,7 @@ def test_forecast_dataset_init_forecast_hindcast_mismatch_error(
     cfg.update_config({'hindcast_inputs': []})
     with pytest.raises(
         ValueError,
-        match='`hindcast_inputs` must be supplied.',
+        match='hindcast_inputs must be supplied.',
     ):
         Multimet(cfg=cfg, is_train=True, period='train')
 

--- a/test/test_multimet.py
+++ b/test/test_multimet.py
@@ -46,7 +46,6 @@ def _get_default_config_attributes(**kwargs):
         'targets_data_dir': Path('/tmp/data/targets'),
         'nan_handling_method': 'none',
         'timestep_counter': False,
-        'use_basin_id_encoding': False,
         'train_start_date': ['01/01/2000', '01/02/2006'],
         'train_end_date': ['03/01/2000', '03/02/2006'],
         'test_start_date': '01/01/2000',
@@ -407,20 +406,20 @@ def test_forecast_dataset_init_forecast_hindcast_mismatch_error(
     # Case 1: No inputs are supplied
     cfg = get_config('default')
     cfg.update_config(
-        {'hindcast_inputs': [], 'forecast_inputs': [], 'dynamic_inputs': []}
+        {'hindcast_inputs': [], 'forecast_inputs': []}
     )
     with pytest.raises(
         ValueError,
-        match='Either `hindcast_inputs` or `dynamic_inputs` must be supplied.',
+        match='`hindcast_inputs` must be supplied.',
     ):
         Multimet(cfg=cfg, is_train=True, period='train')
 
-    # Case 2: Neither dynamic_inputs nor hindcast_inputs are supplied
+    # Case 2: Hindcast_inputs are not supplied
     cfg = get_config('default')
-    cfg.update_config({'hindcast_inputs': [], 'dynamic_inputs': []})
+    cfg.update_config({'hindcast_inputs': []})
     with pytest.raises(
         ValueError,
-        match='Either `hindcast_inputs` or `dynamic_inputs` must be supplied.',
+        match='`hindcast_inputs` must be supplied.',
     ):
         Multimet(cfg=cfg, is_train=True, period='train')
 

--- a/test/test_validate_samples.py
+++ b/test/test_validate_samples.py
@@ -19,8 +19,6 @@ import pytest
 from unittest.mock import patch, ANY
 
 from googlehydrology.datautils.validate_samples import (
-    _flatten_feature_groups,
-    extract_feature_groups,
     validate_samples,
     validate_samples_for_nan_handling,
     validate_samples_any_all_group,
@@ -743,11 +741,7 @@ def test_validate_sequence_any_shift_right(sample_dates_fixture):
 )
 @patch('googlehydrology.datautils.validate_samples.validate_sequence_all')
 @patch('googlehydrology.datautils.validate_samples.validate_sequence_any')
-@patch('googlehydrology.datautils.validate_samples._flatten_feature_groups')
-@patch('googlehydrology.datautils.validate_samples.extract_feature_groups')
 def test_validate_samples_no_features_raises_error(
-    mock_extract_feature_groups,
-    mock_flatten_feature_groups,
     mock_validate_sequence_any,
     mock_validate_sequence_all,
     mock_validate_samples_for_nan_handling,
@@ -777,8 +771,6 @@ def test_validate_samples_no_features_raises_error(
     mock_validate_samples_for_nan_handling.assert_not_called()
     mock_validate_sequence_all.assert_not_called()
     mock_validate_sequence_any.assert_not_called()
-    mock_flatten_feature_groups.assert_not_called()
-    mock_extract_feature_groups.assert_not_called()
 
 
 @patch('googlehydrology.datautils.validate_samples.validate_samples_any')
@@ -788,11 +780,7 @@ def test_validate_samples_no_features_raises_error(
 )
 @patch('googlehydrology.datautils.validate_samples.validate_sequence_all')
 @patch('googlehydrology.datautils.validate_samples.validate_sequence_any')
-@patch('googlehydrology.datautils.validate_samples._flatten_feature_groups')
-@patch('googlehydrology.datautils.validate_samples.extract_feature_groups')
 def test_validate_samples_static_features_only(
-    mock_extract_feature_groups,
-    mock_flatten_feature_groups,
     mock_validate_sequence_any,
     mock_validate_sequence_all,
     mock_validate_samples_for_nan_handling,
@@ -833,8 +821,6 @@ def test_validate_samples_static_features_only(
     mock_validate_samples_any.assert_not_called()
     mock_validate_sequence_any.assert_not_called()
     mock_validate_sequence_all.assert_not_called()
-    mock_flatten_feature_groups.assert_not_called()
-    mock_extract_feature_groups.assert_not_called()
     assert len(masks) == 2
     assert masks[0].name == 'statics'
     assert masks[1].name == 'dates'


### PR DESCRIPTION
Several unit tests were broken based on recent changes. The following tests are fixed:

1) `test_config_runs.py` --> removed unused config args and updated the call to caravan's `load_caravan_timeseries` (now called `load_caravan_timeseries_together`). 

2) `test_multimet.py` --> fixed expected error messages due to removal of dynamic_imports as a config option. 

3) `test_validate_samples.py` --> removed references to functions that were removed as part of the cleanup.

The `test_uncertainty.py` was NOT updated in this PR and is still broken. All other tests work.

Future work should increase test coverage beyond the current 71%.