### PR TITLE
Fixed scaler test and updated conda env for h5netcdf.

### DIFF
--- a/environments/conda.yml
+++ b/environments/conda.yml
@@ -30,9 +30,9 @@ dependencies:
   - dask
   - gcsfs
   - gh
+  - h5netcdf
   - h5py
   - hdf5
-  - h5netcdf
   - ipython
   - jupyter
   - matplotlib

--- a/environments/conda.yml
+++ b/environments/conda.yml
@@ -32,6 +32,7 @@ dependencies:
   - gh
   - h5py
   - hdf5
+  - h5netcdf
   - ipython
   - jupyter
   - matplotlib

--- a/test/test_scaler.py
+++ b/test/test_scaler.py
@@ -562,8 +562,8 @@ def test_scaler_load_from_file_raises_error_for_zero_scale(tmp_scaler_dir):
         coords={'parameter': ['center', 'scale', 'mean', 'std']},
     )
     os.makedirs(tmp_scaler_dir, exist_ok=True)
-    with open(scaler_file_path, 'wb') as f:
-        zero_scale_ds.to_netcdf(f)
+    with open(scaler_file_path, 'w+b') as f:
+        zero_scale_ds.to_netcdf(f, engine='h5netcdf')
 
     # Now try to load this scaler and expect a ValueError
     with pytest.raises(


### PR DESCRIPTION
Conda environment needs h5netcdf after recent changes. Also, one of the unit tests needed to be updated to explicitly save the scaler with h5netcdf.