### PR TITLE
[optimize memory] make index_sampler dict virtual so it takes no memory.

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -242,9 +242,6 @@ class Multimet(Dataset):
         LOGGER.debug('scale data')
         self._dataset = self.scaler.scale(self._dataset)
 
-        LOGGER.debug('create valid sample mask and indices')
-        valid_sample_mask, indices = self._create_valid_sample_mask()
-
         # TODO: Optionally, optimize the data loader and trainer modules to work with chunked lazy data.
         LOGGER.debug('compute dataset, scaler')
         # We explicitly keep the self.scaler.scaler computation since trainer uses it directly

--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -16,12 +16,11 @@ import functools
 import itertools
 import logging
 import math
-import multiprocessing
 import pickle
 import subprocess
 import sys
+from collections.abc import Hashable, Iterable, Iterator
 from pathlib import Path
-from typing import Hashable, Iterable
 
 import dask
 import dask.array
@@ -29,6 +28,7 @@ import numpy as np
 import pandas as pd
 import torch
 import xarray as xr
+from dask.sizeof import sizeof
 from torch.utils.data import Dataset
 
 from googlehydrology.datasetzoo.caravan import (
@@ -246,22 +246,23 @@ class Multimet(Dataset):
         valid_sample_mask, indices = self._create_valid_sample_mask()
 
         # TODO: Optionally, optimize the data loader and trainer modules to work with chunked lazy data.
-        LOGGER.debug('materialize data (compute)')
+        LOGGER.debug('compute dataset, scaler')
         # We explicitly keep the self.scaler.scaler computation since trainer uses it directly
-        with multiprocessing.Pool(processes=1) as pool:
-            self._dataset, self.scaler.scaler, indices = dask.compute(
-                self._dataset,
-                self.scaler.scaler,
-                indices,
-                pool=pool,
-                scheduler='processes',
-            )
-
+        (self._dataset, self.scaler.scaler) = dask.compute(
+            self._dataset, self.scaler.scaler
+        )
+        LOGGER.debug(f'Dataset size: {sizeof(self._dataset) / 1024 / 1024} MB')
         LOGGER.debug('scaler check zero scale')
         self.scaler.check_zero_scale()
         LOGGER.debug('scaler save')
         self.scaler.save()
 
+        LOGGER.debug('create valid sample mask and indices')
+        valid_sample_mask, indices = self._create_valid_sample_mask()
+        (indices,) = dask.compute(indices)
+        LOGGER.debug(
+            f'Sample masks indices size: {sizeof(indices) / 1024 / 1024} MB'
+        )
         # Create sample index lookup table for `__getitem__`.
         self._create_sample_index(valid_sample_mask, indices)
 
@@ -513,9 +514,10 @@ class Multimet(Dataset):
     def _create_sample_index(
         self, valid_sample_mask: xr.DataArray, indices: np.ndarray
     ):
-        """Creates a map from integer sample indexes to the integer positions into the xr.Dataset.
+        """Map int sample indexes to the int positions into the xr.Dataset.
 
-        This allows index-based sample retrieval, which is faster than coordinate-based sample retrieval.
+        Allows index-based sample retrieval, faster than coordinate-based sample
+        retrieval.
         """
         # Count the number of valid samples.
         num_samples = len(indices[0]) if indices else 0
@@ -525,26 +527,16 @@ class Multimet(Dataset):
             else:
                 raise NoEvaluationDataError
 
-        # Maps dim name to its respective list of int indices (index arrays) i.e. columns
-        # of all basins, all dates, etc.
-        vectorized_indices = {
-            dim: indices[i]
+        # Align dim name with its respective list of int indices (index arrays),
+        # i.e. columns of all basins, all dates, etc.
+        aligned_indices = tuple(
+            (dim, indices[i])
             for i, dim in enumerate(valid_sample_mask.dims)
             if dim != 'sample'
-        }
+        )
 
         LOGGER.debug('sample_index')
-        # Reorg columns to rows, mapping sample index i [0, num_samples) to a dict that
-        # maps an int position for that sample in each dim. E.g. {1: {'basin': 2, 'date': 3}}
-        #
-        # This allows integer indexing into each coordinate dimension of the original dataset,
-        # while ONLY selecting valid samples. The full original dataset is retained (including
-        # not-valid samples) for sequence construction.
-        self._sample_index = {
-            i: {dim: indexes[i] for dim, indexes in vectorized_indices.items()}
-            for i in range(num_samples)
-        }
-
+        self._sample_index = SampleIndexer(aligned_indices)
         self._num_samples = num_samples
 
     def _extract_dataset(
@@ -983,3 +975,28 @@ def _get_products_and_bands_from_feature_strings(
             product = 'ERA5_LAND'
         product_bands.setdefault(product, []).append(feature)
     return product_bands
+
+class SampleIndexer:
+    """Reorg columns to rows.
+
+    Map sample index i [0, num_samples) to a dict that maps an int
+    position for that sample in each dim.
+    E.g. {1: {'basin': 2, 'date': 3}}
+
+    This allows integer indexing into each coordinate dimension of
+    the original dataset, while ONLY selecting valid samples. The full
+    original dataset is retained (including not-valid samples) for
+    sequence construction.
+    """
+
+    def __init__(self, aligned_indices: tuple[tuple[str, np.ndarray]]) -> None:
+        self._aligned_indices = aligned_indices
+
+    def __getitem__(self, item: int) -> dict[str, int]:
+        return {dim: indexes[item] for dim, indexes in self._aligned_indices}
+
+    def items(self) -> Iterator[tuple[int, dict[str, int]]]:
+        return enumerate(self[i] for i in range(len(self)))
+
+    def __len__(self) -> int:
+        return len(self._aligned_indices[0][1])

--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -1005,4 +1005,5 @@ class SampleIndexer:
         return zip(self.keys(), self.values())
 
     def __len__(self) -> int:
-        return len(self._aligned_indices[0][1])
+        _, indexes = self._aligned_indices[0]
+        return len(indexes)

--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -995,8 +995,14 @@ class SampleIndexer:
     def __getitem__(self, item: int) -> dict[str, int]:
         return {dim: indexes[item] for dim, indexes in self._aligned_indices}
 
+    def keys(self) -> Iterator[int]:
+        return range(len(self))
+
+    def values(self) -> Iterator[dict[str, int]]:
+        return (self[i] for i in self.keys())
+
     def items(self) -> Iterator[tuple[int, dict[str, int]]]:
-        return enumerate(self[i] for i in range(len(self)))
+        return zip(self.keys(), self.values())
 
     def __len__(self) -> int:
         return len(self._aligned_indices[0][1])

--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -481,6 +481,11 @@ class Multimet(Dataset):
         return functools.reduce(pd.Index.union, ranges)
 
     def _create_valid_sample_mask(self):
+        """Map int sample indexes to the int positions into the xr.Dataset.
+
+        Allows index-based sample retrieval, faster than coordinate-based sample
+        retrieval.
+        """
         # Create a boolean mask for the original dataset noting valid (True) vs. invalid (False) samples.
         valid_sample_mask = validate_samples(
             is_train=self.is_train,
@@ -511,11 +516,7 @@ class Multimet(Dataset):
     def _create_sample_index(
         self, valid_sample_mask: xr.DataArray, indices: np.ndarray
     ):
-        """Map int sample indexes to the int positions into the xr.Dataset.
-
-        Allows index-based sample retrieval, faster than coordinate-based sample
-        retrieval.
-        """
+        """Create the sample index structure to access the mapping."""
         # Count the number of valid samples.
         num_samples = len(indices[0]) if indices else 0
         if num_samples == 0:

--- a/test/test_tester.py
+++ b/test/test_tester.py
@@ -13,33 +13,41 @@
 # limitations under the License.
 
 from math import ceil
+
 import pytest
 
+from googlehydrology.datasetzoo.multimet import SampleIndexer
 from googlehydrology.evaluation.utils import BasinBatchSampler
 
 
 @pytest.fixture
 def fixure():
-    sample_index = {  # sample index -> basin metadata
-        # basin 101: 7 samples, 3 batches
-        0: {'basin': 101, 'date': 1},
-        1: {'basin': 101, 'date': 2},
-        2: {'basin': 101, 'date': 3},
-        3: {'basin': 101, 'date': 4},
-        4: {'basin': 101, 'date': 5},
-        5: {'basin': 101, 'date': 6},
-        6: {'basin': 101, 'date': 7},
-        # basin 102: 6 samples, 2 batches
-        7: {'basin': 102, 'date': 1},
-        8: {'basin': 102, 'date': 2},
-        9: {'basin': 102, 'date': 3},
-        10: {'basin': 102, 'date': 4},
-        11: {'basin': 102, 'date': 5},
-        12: {'basin': 102, 'date': 6},
-        # basin 103: 2 samples, 1 batch
-        13: {'basin': 103, 'date': 1},
-        14: {'basin': 103, 'date': 2},
-    }
+    sample_index = SampleIndexer(  # sample index -> basin metadata
+        (
+            (
+                'basin',
+                [
+                    # 7 samples, 3 batches
+                    *[101, 101, 101, 101, 101, 101, 101],
+                    # 6 samples, 2 batches
+                    *[102, 102, 102, 102, 102, 102],
+                    # 2 samples, 1 batch
+                    *[103, 103],
+                ],
+            ),
+            (
+                'date',
+                [
+                    # 7 samples, 3 batches
+                    *[1, 2, 3, 4, 5, 6, 7],
+                    # 6 samples, 2 batches
+                    *[1, 2, 3, 4, 5, 6],
+                    # 2 samples, 1 batch
+                    *[1, 2],
+                ],
+            ),
+        )
+    )
 
     expected_groups = {  # basin id -> expected sample indexes
         101: [0, 1, 2, 3, 4, 5, 6],
@@ -121,9 +129,12 @@ def test_one_basin_per_batch(fixure):
 
 def test_sampler_with_single_basin(fixure):
     """Test that the sampler works with one basin."""
-    sample_index = {
-        k: v for k, v in fixure['sample_index'].items() if v['basin'] == 101
-    }
+    sample_index = SampleIndexer(
+        (
+            ('basin', [101, 101, 101, 101, 101, 101, 101]),
+            ('date', [1, 2, 3, 4, 5, 6, 7]),
+        ),
+    )
     sampler = BasinBatchSampler(
         sample_index, batch_size=3, basins_indexes=set()
     )
@@ -136,7 +147,7 @@ def test_sampler_with_single_basin(fixure):
 
 def test_sampler_with_batch_size_larger_than_samples():
     """Test behavior when a basin has fewer samples than the batch size."""
-    sample_index = {0: {'basin': 201}, 1: {'basin': 201}}
+    sample_index = SampleIndexer((('basin', [201, 201]),))
     sampler = BasinBatchSampler(
         sample_index, batch_size=5, basins_indexes=set()
     )

--- a/test/test_tester.py
+++ b/test/test_tester.py
@@ -14,6 +14,7 @@
 
 from math import ceil
 
+import numpy as np
 import pytest
 
 from googlehydrology.datasetzoo.multimet import SampleIndexer
@@ -26,25 +27,29 @@ def fixure():
         (
             (
                 'basin',
-                [
-                    # 7 samples, 3 batches
-                    *[101, 101, 101, 101, 101, 101, 101],
-                    # 6 samples, 2 batches
-                    *[102, 102, 102, 102, 102, 102],
-                    # 2 samples, 1 batch
-                    *[103, 103],
-                ],
+                np.array(
+                    [
+                        # basin 101: 7 samples, 3 batches
+                        *[101, 101, 101, 101, 101, 101, 101],
+                        # basin 102: 6 samples, 2 batches
+                        *[102, 102, 102, 102, 102, 102],
+                        # basin 103: 2 samples, 1 batch
+                        *[103, 103],
+                    ]
+                ),
             ),
             (
                 'date',
-                [
-                    # 7 samples, 3 batches
-                    *[1, 2, 3, 4, 5, 6, 7],
-                    # 6 samples, 2 batches
-                    *[1, 2, 3, 4, 5, 6],
-                    # 2 samples, 1 batch
-                    *[1, 2],
-                ],
+                np.array(
+                    [
+                        # basin 101: 7 samples, 3 batches
+                        *[1, 2, 3, 4, 5, 6, 7],
+                        # basin 102: 6 samples, 2 batches
+                        *[1, 2, 3, 4, 5, 6],
+                        # basin 103: 2 samples, 1 batch
+                        *[1, 2],
+                    ]
+                ),
             ),
         )
     )
@@ -131,8 +136,8 @@ def test_sampler_with_single_basin(fixure):
     """Test that the sampler works with one basin."""
     sample_index = SampleIndexer(
         (
-            ('basin', [101, 101, 101, 101, 101, 101, 101]),
-            ('date', [1, 2, 3, 4, 5, 6, 7]),
+            ('basin', np.array([101, 101, 101, 101, 101, 101, 101])),
+            ('date', np.array([1, 2, 3, 4, 5, 6, 7])),
         ),
     )
     sampler = BasinBatchSampler(
@@ -147,7 +152,7 @@ def test_sampler_with_single_basin(fixure):
 
 def test_sampler_with_batch_size_larger_than_samples():
     """Test behavior when a basin has fewer samples than the batch size."""
-    sample_index = SampleIndexer((('basin', [201, 201]),))
+    sample_index = SampleIndexer((('basin', np.array([201, 201])),))
     sampler = BasinBatchSampler(
         sample_index, batch_size=5, basins_indexes=set()
     )


### PR DESCRIPTION
Implement SampleIndexer which creates items on the fly.
This saves 50GB for a dataset period of 46 years over all 16k basins. (Indices take 1.7GB.)

(Note: the dict was efficient to create runtime-wise (1 min).)

I did a verification to assert a computed dict out of SampleIndexer equalled to the created dict.

Noting that `items` may be improved to avoid calling `__getitem__` repeatedly.

---

This PR also splits the dict creation function into two: valid samples mask and indices being returned to init so it can compute() on it in separate, and the dict creation itself.