### PR TITLE
Use netcdf4.

### DIFF
--- a/googlehydrology/datasetzoo/caravan.py
+++ b/googlehydrology/datasetzoo/caravan.py
@@ -198,7 +198,7 @@ def load_caravan_timeseries_together(
         parallel=False,  # open_mfdataset has a bug (seg fault) when True
         chunks={'date': 'auto'},
         join='outer',
-        engine='h5netcdf',
+        engine='netcdf4',
     ).assign_coords(basin=basins)
 
 

--- a/googlehydrology/datautils/scaler.py
+++ b/googlehydrology/datautils/scaler.py
@@ -171,7 +171,7 @@ class Scaler:
         os.makedirs(self.scaler_dir, exist_ok=True)
         scaler_file = self.scaler_dir / SCALER_FILE_NAME
         with open(scaler_file, 'w+b') as f:
-            self.scaler.to_netcdf(f, engine='netcdf')
+            self.scaler.to_netcdf(f, engine='netcdf4')
 
     def check_zero_scale(self):
         _assert_computed(self.scaler)

--- a/googlehydrology/datautils/scaler.py
+++ b/googlehydrology/datautils/scaler.py
@@ -171,7 +171,7 @@ class Scaler:
         os.makedirs(self.scaler_dir, exist_ok=True)
         scaler_file = self.scaler_dir / SCALER_FILE_NAME
         with open(scaler_file, 'w+b') as f:
-            self.scaler.to_netcdf(f, engine='h5netcdf')
+            self.scaler.to_netcdf(f, engine='netcdf')
 
     def check_zero_scale(self):
         _assert_computed(self.scaler)

--- a/test/test_scaler.py
+++ b/test/test_scaler.py
@@ -563,7 +563,7 @@ def test_scaler_load_from_file_raises_error_for_zero_scale(tmp_scaler_dir):
     )
     os.makedirs(tmp_scaler_dir, exist_ok=True)
     with open(scaler_file_path, 'w+b') as f:
-        zero_scale_ds.to_netcdf(f, engine='h5netcdf')
+        zero_scale_ds.to_netcdf(f, engine='netcdf')
 
     # Now try to load this scaler and expect a ValueError
     with pytest.raises(

--- a/test/test_scaler.py
+++ b/test/test_scaler.py
@@ -563,7 +563,7 @@ def test_scaler_load_from_file_raises_error_for_zero_scale(tmp_scaler_dir):
     )
     os.makedirs(tmp_scaler_dir, exist_ok=True)
     with open(scaler_file_path, 'w+b') as f:
-        zero_scale_ds.to_netcdf(f, engine='netcdf')
+        zero_scale_ds.to_netcdf(f, engine='netcdf4')
 
     # Now try to load this scaler and expect a ValueError
     with pytest.raises(


### PR DESCRIPTION
h5netcdf is a newer version but it suffers from all the same issues as netcdf4, eventually being an old C implementation too that allocates global variables non-thread-safely.

We used netcdf4 during all of this time, so let's 'isolate parameters' (changes), and use netcdf4 again for the time being.