### PR TITLE
[safety] Set xarray's file_cache_maxsize to 1.

### DIFF
--- a/googlehydrology/datasetzoo/caravan.py
+++ b/googlehydrology/datasetzoo/caravan.py
@@ -195,7 +195,7 @@ def load_caravan_timeseries_together(
         preprocess=select,
         combine='nested',
         concat_dim='basin',
-        parallel=False,  # open_mfdataset has a bug (seg fault) when True
+        parallel=False,  # segfault when True
         chunks={'date': 'auto'},
         join='outer',
         engine='netcdf4',

--- a/googlehydrology/run.py
+++ b/googlehydrology/run.py
@@ -22,6 +22,7 @@ import cachey
 import dask
 import dask.cache
 import torch
+import xarray
 
 # make sure code directory is in path, even if the package is not installed using the setup.py
 sys.path.append(str(Path(__file__).parent.parent))
@@ -99,6 +100,9 @@ def _main():
 
     if config.cache.enabled:
         dask.cache.Cache(cachey.Cache(config.cache.byte_limit)).register()
+
+    # engines netcdf4 and h5netcdf fail parallelizing anyway
+    xarray.set_options(file_cache_maxsize=1)
 
     if args['mode'] == 'train':
         start_run(config=config, gpu=args['gpu'])


### PR DESCRIPTION
netcdf4 and h5netcdf can't parallelize anyway, so it's safer to cap file handles to just one.