### PR TITLE
[optimize] Reimplement BasinBatchSampler to lower memory and runtime

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -1005,3 +1005,6 @@ class SampleIndexer:
     def __len__(self) -> int:
         _, indexes = self._aligned_indices[0]
         return len(indexes)
+
+    def get_column(self, dim: str):
+        return next(v for (k, v) in self._aligned_indices if k == dim)

--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -236,8 +236,8 @@ class BaseTester(object):
         batch_sampler = BasinBatchSampler(
             sample_index=self.dataset._sample_index,
             batch_size=self.cfg.batch_size,
-            basins_indexes=set(
-                get_samples_indexes(self.basins, samples=list(basins))
+            basins_indexes=get_samples_indexes(
+                self.basins, samples=list(basins)
             ),
         )
         loader = DataLoader(

--- a/googlehydrology/evaluation/utils.py
+++ b/googlehydrology/evaluation/utils.py
@@ -97,7 +97,7 @@ class BasinBatchSampler(BatchSampler):
             # Counts are ends - starts ie the distance (diff) eg [3,1,4,2]
             self._starts, self._counts = bounds[:-1], np.diff(bounds)
         # Array lengths are in terms of num basins eg len changes, len starts,
-        # etc. Or use bool masks that are 1 byte instead of 8 bytes (64 bit) so
+        # etc. Or bool masks that are 1 byte instead of 8 bytes (64 bit) so
         # the col's compare size is 1/8 of col.
 
         fulls, remainders = np.divmod(self._counts, batch_size)

--- a/googlehydrology/evaluation/utils.py
+++ b/googlehydrology/evaluation/utils.py
@@ -21,6 +21,8 @@ import numpy as np
 import pandas as pd
 from torch.utils.data import BatchSampler, SequentialSampler
 
+from googlehydrology.datasetzoo.multimet import SampleIndexer
+
 
 def metrics_to_dataframe(
     results: dict, metrics: Iterable[str], targets: Iterable[str]
@@ -71,32 +73,41 @@ class BasinBatchSampler(BatchSampler):
 
     def __init__(
         self,
-        sample_index: dict[int, dict[str, int]],
+        sample_index: SampleIndexer,
         batch_size: int,
-        basins_indexes: set[int],
+        basins_indexes: np.typing.NDArray[np.integer],
     ):
         super().__init__(
             SequentialSampler(range(len(sample_index))),
             batch_size,
             drop_last=False,
         )
+        self.batch_size = batch_size
 
-        self._batch_size = batch_size
+        col = sample_index.get_column('basin')
 
-        self._basin_indices: dict[int, list[int]] = {}
-        for sample, data in sample_index.items():
-            basin_index = data['basin']
-            if (not basins_indexes) or basin_index in basins_indexes:
-                self._basin_indices.setdefault(basin_index, []).append(sample)
+        if len(basins_indexes):  # Binary search the already sorted indexes
+            starts = np.searchsorted(col, basins_indexes, side='left')
+            ends = np.searchsorted(col, basins_indexes, side='right')
+            self._starts, self._counts = starts, ends - starts
+        else:  # Find boundary changes eg for all [0,0,0,1,2,2,2,2,3,3]
+            changes = np.flatnonzero(col[:-1] != col[1:]) + 1
+            bounds = np.concatenate(([0], changes, [len(col)]))
+            # Starts are bounds' left edges eg [0,3,4,8](,10)
+            # Counts are ends - starts ie the distance (diff) eg [3,1,4,2]
+            self._starts, self._counts = bounds[:-1], np.diff(bounds)
+        # Array lengths are in terms of num basins eg len changes, len starts,
+        # etc. Or use bool masks that are 1 byte instead of 8 bytes (64 bit) so
+        # the col's compare size is 1/8 of col.
 
-        self._num_batches = sum(
-            math.ceil(len(indices) / batch_size)
-            for indices in self._basin_indices.values()
-        )
+        fulls, remainders = np.divmod(self._counts, batch_size)
+        self._num_batches = int(fulls.sum() + np.count_nonzero(remainders))
+
 
     def __iter__(self):
-        for indices in self._basin_indices.values():  # for every basin
-            yield from itertools.batched(indices, self._batch_size)
+        for start, count in zip(self._starts, self._counts, strict=True):
+            end = start + count
+            yield from itertools.batched(range(start, end), self.batch_size)
 
     def __len__(self):
         return self._num_batches

--- a/googlehydrology/evaluation/utils.py
+++ b/googlehydrology/evaluation/utils.py
@@ -82,7 +82,7 @@ class BasinBatchSampler(BatchSampler):
             batch_size,
             drop_last=False,
         )
-        self.batch_size = batch_size
+        self._batch_size = batch_size
 
         col = sample_index.get_column('basin')
 
@@ -107,7 +107,7 @@ class BasinBatchSampler(BatchSampler):
     def __iter__(self):
         for start, count in zip(self._starts, self._counts, strict=True):
             end = start + count
-            yield from itertools.batched(range(start, end), self.batch_size)
+            yield from itertools.batched(range(start, end), self._batch_size)
 
     def __len__(self):
         return self._num_batches


### PR DESCRIPTION
Limit memory on num basins and runtime to sub second for 16k basins.

Binary search via numpy on already sorted computed indexes instead of a dict to store and resort it. So memory spike is some k times num basins. The dict impl was problematic as it iterated on values and small dicts created on the fly for all values: memory and runtime.

For the 671 camels basin list over 46yr: the dict held 622MB. Runtime was hundreds of seconds for 16k basins at each validation epoc.

The computed indices for each samples are in a flat array (column) like [0,0,0,1,2,2,2,2,3,3,....]. So getting left and right edges via numpy: [0,3,4,8,...] [3,4,8,10,...]. Each defines the batch for a basin in that order [0,1,2] (from the 0,0,0 part) hence the range(0,3) when yielding the batch.

Else for the all basins case, we can look at the col offsetted by one and have numpy find the boundary changes ie where there's differing values. The boundaries are those values offsetted right by one because end indices should always be exclusive ie bounds... Then to get the distances/lengths/counts, np.diff returns that result.

Tested for equality exactly for both 671 basins 1950-2025 and for 16k basins 1980-2025, and the unit tests.