### PR TITLE
[optimize memory] Calculate std in scaler via means.

### DIFF
--- a/googlehydrology/datautils/scaler.py
+++ b/googlehydrology/datautils/scaler.py
@@ -27,16 +27,24 @@ SCALER_FILE_NAME = 'scaler.nc'
 def _calc_stats(dataset: xr.Dataset, needed: set[str]):
     stats = {
         'mean': dataset.mean(skipna=True),
-        'std': dataset.std(skipna=True),
         'median': (
             dataset.quantile(q=0.5, skipna=True) if 'median' in needed else None
         ),
         'min': dataset.min(skipna=True) if {'min', 'minmax'} & needed else None,
         'max': dataset.max(skipna=True) if {'max', 'minmax'} & needed else None,
     }
+
     stats['minmax'] = (
         stats['max'] - stats['min'] if 'minmax' in needed else None
     )
+
+    # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance (Naive):
+    # Var(X) = E[X**2] - E**2[X] instead of xr.std that subtracts mean from all
+    # elements, to force dask work element wise. Non negative var failsafes if
+    # there is propagating cancellation.
+    var = (dataset**2).mean(skipna=True) - stats['mean'] ** 2
+    stats['std'] = var.clip(min=0) ** 0.5
+
     return stats
 
 

--- a/googlehydrology/datautils/scaler.py
+++ b/googlehydrology/datautils/scaler.py
@@ -41,7 +41,7 @@ def _calc_stats(dataset: xr.Dataset, needed: set[str]):
     # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance (Naive):
     # Var(X) = E[X**2] - E**2[X] instead of xr.std that subtracts mean from all
     # elements, to force dask work element wise. Non negative var failsafes if
-    # there is propagating cancellation.
+    # there is propagating cancellation. For benchmark ds abs error was < 0.0001
     var = (dataset**2).mean(skipna=True) - stats['mean'] ** 2
     stats['std'] = var.clip(min=0) ** 0.5
 


### PR DESCRIPTION
dask xarray.std caches the dataset in memory. Data values don't seem huge so the expectancies `E[DS**2]` and `E**2[DS]` are not two large figures with little diff. So it appears we can use the naive formula instead of truely stable and accurate one. For the benchmark dataset absolute error wasn't more than 0.0001 for the std values.

Goal is to reduce memory to O(1) (mean and mean of independently squared numbers).