### PR TITLE
Release freed memory post load data back to the OS to prevent mem fragmentation

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -158,6 +158,7 @@ class Multimet(Dataset):
         # Load & preprocess the data.
         LOGGER.debug('load data')
         self._dataset = self._load_data()
+        memory.release()
         LOGGER.debug('validate all floats are float32')
         _assert_floats_are_float32(self._dataset)
 

--- a/googlehydrology/utils/memory.py
+++ b/googlehydrology/utils/memory.py
@@ -3,6 +3,7 @@
 import contextlib
 import ctypes
 import gc
+from ctypes.util import find_library
 
 
 def release() -> None:
@@ -22,5 +23,5 @@ def release() -> None:
     """
     gc.collect()
 
-    with contextlib.suppress(OSError):  # Ignore if not Unix-like
-        ctypes.CDLL('libc.so.6').malloc_trim(0)
+    with contextlib.suppress(OSError, AttributeError):  # Ignore non Unix-like
+        ctypes.CDLL(find_library('c') or 'libc.so.6').malloc_trim(0)

--- a/googlehydrology/utils/memory.py
+++ b/googlehydrology/utils/memory.py
@@ -1,0 +1,26 @@
+"""Memory utils."""
+
+import contextlib
+import ctypes
+import gc
+
+
+def release() -> None:
+    """Collect freed memory, and trim on Linux-like systems.
+
+    Return freed C memory to the OS. This has two purposes:
+    1. OS allocates us new defragmented allocs when needed.
+    2. Prevent races where memory is fragmented, and we ask
+       for new allocs yet the underlying allocator didn't
+       return the fragmented memory yet. In this case,
+       we both allocate even more memory while holding onto
+       memory that isn't used yet because it's fragmented
+       and it was too fast to get reused.
+
+    Linux supports trim. MacOS and Windows release freed
+    memory more aggressively automatically.
+    """
+    gc.collect()
+
+    with contextlib.suppress(OSError):  # Ignore if not Unix-like
+        ctypes.CDLL('libc.so.6').malloc_trim(0)


### PR DESCRIPTION
For the full caravan over 46yr, 28GB -> 5.5GB at this point.

More memory is used when capacity is higher on a machine, so that figure changes with a machine's spec as dask chooses how much memory to use (num workers in a process and by chunk size).

However, the documentation in memory.py explains why do this. It's better to release unused memory explicitly than risk concurrent racing due to allocations' fragmentation.

The code is compatible/portable for every Linux that uses libc, which is effectively everything: Android isn't a target to support, but anyway a library like musl or bionic libc instead of libc seems not to have trim anyway. In such cases, trimming just won't take place.