### PR TITLE
Remove num workers from dask config.

### DIFF
--- a/googlehydrology/run.py
+++ b/googlehydrology/run.py
@@ -15,7 +15,6 @@
 
 import argparse
 import logging
-import os
 import sys
 from pathlib import Path
 
@@ -92,7 +91,6 @@ def _main():
     torch.autograd.set_detect_anomaly(config.detect_anomaly)
 
     dask_config = {
-        'num_workers': os.cpu_count(),
         'scheduler': 'threads',
         'shuffle': 'p2p',
     }


### PR DESCRIPTION
It defaults to num CPU cores.

https://docs.dask.org/en/latest/scheduler-overview.html#configuring-the-schedulers