### PR TITLE
Fix logging. Pbar updates were overlapping often and it's needed for next PRs.

### DIFF
--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -28,7 +28,6 @@ import torch.cuda
 import xarray
 from torch.amp import autocast
 from torch.utils.data import DataLoader, Dataset
-from tqdm import tqdm
 
 from googlehydrology.datasetzoo import get_dataset
 from googlehydrology.datautils.utils import (

--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -52,6 +52,7 @@ from googlehydrology.training import get_loss_obj, get_regularization_obj
 from googlehydrology.training.logger import Logger, do_log_figures
 from googlehydrology.utils.config import Config, TesterSamplesReduction
 from googlehydrology.utils.errors import AllNaNError
+from googlehydrology.utils.tqdm import AutoRefreshTqdm as tqdm
 
 LOGGER = logging.getLogger(__name__)
 

--- a/googlehydrology/run.py
+++ b/googlehydrology/run.py
@@ -26,6 +26,8 @@ import torch
 import tqdm.dask
 import xarray
 
+from googlehydrology.utils.tqdm import AutoRefreshTqdm
+
 # make sure code directory is in path, even if the package is not installed using the setup.py
 sys.path.append(str(Path(__file__).parent.parent))
 from googlehydrology.evaluation.evaluate import start_evaluation
@@ -109,6 +111,7 @@ def _main():
             unit=' tasks',
             desc='compute',
             unit_scale=True,
+            tqdm_class=AutoRefreshTqdm,
         ).register()
 
     # engines netcdf4 and h5netcdf fail parallelizing anyway

--- a/googlehydrology/training/basetrainer.py
+++ b/googlehydrology/training/basetrainer.py
@@ -40,6 +40,7 @@ from googlehydrology.training import (
 from googlehydrology.training.logger import Logger
 from googlehydrology.utils.config import Config
 from googlehydrology.utils.logging_utils import setup_logging
+from googlehydrology.utils.tqdm import AutoRefreshTqdm as tqdm
 
 LOGGER = logging.getLogger(__name__)
 

--- a/googlehydrology/training/basetrainer.py
+++ b/googlehydrology/training/basetrainer.py
@@ -24,7 +24,6 @@ import torch
 import torch.optim.lr_scheduler
 from torch.amp import GradScaler, autocast
 from torch.utils.data import DataLoader, Dataset
-from tqdm import tqdm
 
 import googlehydrology.training.loss as loss
 from googlehydrology.datasetzoo import get_dataset

--- a/googlehydrology/utils/logging_utils.py
+++ b/googlehydrology/utils/logging_utils.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tqdm.contrib.logging import logging_redirect_tqdm
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -77,6 +79,8 @@ def setup_logging(log_file: str, level: int, print_warnings_once: bool):
     logging.getLogger('filelock').setLevel(logging.INFO)
     logging.getLogger('matplotlib.font_manager').setLevel(logging.INFO)
     logging.getLogger('fsspec').setLevel(logging.INFO)
+
+    logging_redirect_tqdm().__enter__()
 
 
 def get_git_hash() -> str | None:

--- a/googlehydrology/utils/tqdm.py
+++ b/googlehydrology/utils/tqdm.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tqdm.auto import tqdm
+
+
+class AutoRefreshTqdm(tqdm):
+    """Refresh all other bars on close and when opening a new bar."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.refresh_all()
+
+    def close(self):
+        super().close()
+        self.refresh_all()
+
+    def refresh_all(self):
+        for pbar in tqdm._instances:
+            if pbar is not self:
+                pbar.refresh()


### PR DESCRIPTION
* Multi bars need calling update on other bars, so to not complicate, this calls on the other instances automatically. Usually we have 1 instance or two. Next PRs for laziness need this even more.
* Tqdm requires calling on tqdm.write. So this needs to work with the logging module that we use which actually resulted in like using print(). That's why bars became glitched when there were log statements prior to them finishing. This fixes that.
* Verified output.log is as expected. Like before, progress bars aren't included in it.

Here's an example output for INFO:
```
otal_precipitation', 'graphcast_u_component_of_wind_10m': 'era5land_u_component_of_wind_10m', 'graphcast_v_component_of_wind_10m': 'era5land_v_component_of_wind_10m', 'hres_surface_net_solar_radiation': 'era5land_surface_net_solar_radiation', 'hres_surface_net_thermal_radiation': 'era5land_surface_net_thermal_radiation', 'hres_surface_pressure': 'era5land_surface_pressure', 'hres_temperature_2m': 'era5land_temperature_2m', 'hres_total_precipitation': 'era5land_total_precipitation'}
[INFO] 13:56:28.450 (basetrainer.py:__init__) -- model: mean_embedding_forecast_lstm
[INFO] 13:56:28.450 (basetrainer.py:__init__) -- forecast_overlap: 365
[INFO] 13:56:28.450 (basetrainer.py:__init__) -- loss: CMALLoss
[INFO] 13:56:28.450 (basetrainer.py:__init__) -- head: cmal
[INFO] 13:56:28.450 (basetrainer.py:__init__) -- n_distributions: 3
[INFO] 13:56:28.450 (basetrainer.py:__init__) -- n_samples: 7500
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- negative_sample_handling: clip
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- hidden_size: 512
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- initial_forget_bias: 3
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- output_dropout: 0.4
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- timestep_counter: True
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- run_dir: /usr/local/google/home/amarkel/nh-data/runs/mean_embedding_forecast_lstm_1301_135628
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- statics_embedding: {'type': 'fc', 'hiddens': [100, 100, 20], 'activation': ['tanh', 'tanh', 'linear'], 'dropout': 0.0}
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- hindcast_embedding: {'type': 'fc', 'hiddens': [100, 20], 'activation': ['tanh', 'linear'], 'dropout': 0.0}
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- forecast_embedding: {'type': 'fc', 'hiddens': [20, 20, 20, 20], 'activation': ['tanh', 'tanh', 'tanh', 'linear'], 'dropout': 0.0}
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- number_of_basins: 3
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- train_dir: /usr/local/google/home/amarkel/nh-data/runs/mean_embedding_forecast_lstm_1301_135628/train_data
[INFO] 13:56:28.460 (basetrainer.py:__init__) -- img_log_dir: /usr/local/google/home/amarkel/nh-data/runs/mean_embedding_forecast_lstm_1301_135628/img_log
[INFO] 13:56:28.480 (basetrainer.py:_set_device) -- ### Device cpu will be used for training
[INFO] 13:56:32.992 (basetrainer.py:train_and_validate) -- learning rate is [0.0005]
# Epoch 1: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.48s/it, Loss: 13.6009]
[INFO] 13:56:35.473 (basetrainer.py:train_and_validate) -- Epoch 1 average loss: avg_loss: 13.60088, avg_total_loss: 13.60088
Metrics for 1D are calculated over last 1 elements only. Ignoring 7 predictions per sequence.
# Validation: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  1.75it/s]
[INFO] 13:56:37.219 (basetrainer.py:train_and_validate) -- Epoch 1 average validation loss: 11.26804 -- Median validation metrics: avg_loss: 11.26804, NSE: -17.77503, KGE: -9.75094
[INFO] 13:56:37.219 (basetrainer.py:train_and_validate) -- learning rate is [0.0005]
# Epoch 2: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.34s/it, Loss: 12.1497]
[INFO] 13:56:39.560 (basetrainer.py:train_and_validate) -- Epoch 2 average loss: avg_learning_rate: 0.00050, avg_loss: 12.14965, avg_total_loss: 12.14965
Metrics for 1D are calculated over last 1 elements only. Ignoring 7 predictions per sequence.
# Validation: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  1.81it/s]
[INFO] 13:56:41.252 (basetrainer.py:train_and_validate) -- Epoch 2 average validation loss: 9.30706 -- Median validation metrics: avg_loss: 9.30706, NSE: -10.33447, KGE: -8.36601
[INFO] 13:56:41.252 (basetrainer.py:train_and_validate) -- learning rate is [0.0005]
# Epoch 3: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.41s/it, Loss: 9.8049]
[INFO] 13:56:43.667 (basetrainer.py:train_and_validate) -- Epoch 3 average loss: avg_learning_rate: 0.00050, avg_loss: 9.80493, avg_total_loss: 9.80493
Metrics for 1D are calculated over last 1 elements only. Ignoring 7 predictions per sequence.
# Validation: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  1.85it/s]
[INFO] 13:56:45.319 (basetrainer.py:train_and_validate) -- Epoch 3 average validation loss: 7.10458 -- Median validation metrics: avg_loss: 7.10458, NSE: -4.95221, KGE: -6.19118
[INFO] 13:56:45.320 (basetrainer.py:train_and_validate) -- learning rate is [0.0005]
# Epoch 4: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.28s/it, Loss: 7.8347]
[INFO] 13:56:47.601 (basetrainer.py:train_and_validate) -- Epoch 4 average loss: avg_learning_rate: 0.00050, avg_loss: 7.83468, avg_total_loss: 7.83468
Metrics for 1D are calculated over last 1 elements only. Ignoring 7 predictions per sequence.
# Validation: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  1.88it/s]
[INFO] 13:56:49.236 (basetrainer.py:train_and_validate) -- Epoch 4 average validation loss: 4.34960 -- Median validation metrics: avg_loss: 4.34960, NSE: -1.32262, KGE: -3.38010
```

And for DEBUG where there'll be 3 bars in lazy mode in DEBUG:
```
compute: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.00/3.00 [00:00<00:00, 59.1 tasks/s]
[DEBUG] 14:24:23.161 (caravan.py:load_caravan_attributes) -- missing
[DEBUG] 14:24:23.168 (multimet.py:_load_data) -- load hindcast features
[DEBUG] 14:24:23.187 (multimet.py:_load_data) -- load forecast features
[DEBUG] 14:24:23.196 (multimet.py:_load_data) -- load target features
[DEBUG] 14:24:23.282 (multimet.py:_load_data) -- merge
[DEBUG] 14:24:23.440 (multimet.py:_load_data) -- chunk
[DEBUG] 14:24:23.448 (multimet.py:_load_data) -- unify_chunks
[DEBUG] 14:24:23.637 (multimet.py:__init__) -- validate all floats are float32
[DEBUG] 14:24:23.639 (multimet.py:__init__) -- reindex data
[DEBUG] 14:24:23.659 (multimet.py:__init__) -- union features
[DEBUG] 14:24:23.815 (multimet.py:__init__) -- init scaler
[DEBUG] 14:24:24.122 (multimet.py:__init__) -- scale data
[DEBUG] 14:24:24.186 (multimet.py:__init__) -- create valid sample mask and indices plan
[DEBUG] 14:24:24.187 (validate_samples.py:validate_samples) -- static_features
[DEBUG] 14:24:24.196 (validate_samples.py:validate_samples) -- hindcast features
[DEBUG] 14:24:24.233 (validate_samples.py:validate_samples) -- forecast features
[DEBUG] 14:24:24.245 (validate_samples.py:validate_samples) -- forecast features:overlap
[DEBUG] 14:24:24.275 (validate_samples.py:validate_samples) -- invalid sample dates
[DEBUG] 14:24:24.277 (validate_samples.py:validate_samples) -- valid_sample_mask
[DEBUG] 14:24:24.289 (multimet.py:__init__) -- [lazy_data] compute scaler, indices
compute: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 976/976 [00:00<00:00, 5.04k tasks/s]
[DEBUG] 14:24:24.547 (multimet.py:__init__) -- [lazy_data] clean memory
[DEBUG] 14:24:24.745 (multimet.py:__init__) -- [lazy_data] apply scale data post scaler compute
[DEBUG] 14:24:24.809 (multimet.py:__init__) -- Dataset size: 0.02141284942626953 MB
[DEBUG] 14:24:24.809 (multimet.py:__init__) -- Sample masks indices size: 0.00147247314453125 MB
[DEBUG] 14:24:24.809 (multimet.py:__init__) -- scaler check zero scale
[DEBUG] 14:24:24.820 (multimet.py:__init__) -- scaler save
[DEBUG] 14:24:24.893 (multimet.py:__init__) -- create sample index
[DEBUG] 14:24:24.894 (multimet.py:__init__) -- forecast dataset init complete (validation)
compute: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 22.0/22.0 [00:00<00:00, 550 tasks/s]
compute: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 22.0/22.0 [00:00<00:00, 528 tasks/s]
compute: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 22.0/22.0 [00:00<00:00, 536 tasks/s]
[INFO] 14:24:25.530 (basetrainer.py:train_and_validate) -- learning rate is [0.0005]
Prepare batch: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 256/256 [00:05<00:00, 44.76 samples/s]
compute: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 41.2k/41.2k [00:04<00:00, 10.3k tasks/s]
# Epoch 1: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:20<00:00, 20.71s/it, Loss: 13.0230]
[INFO] 14:24:45.762 (basetrainer.py:train_and_validate) -- Epoch 1 average loss: avg_loss: 13.02299, avg_total_loss: 13.02299
Prepare batch: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 31/31 [00:00<00:00, 55.92 samples/s]
compute: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5.59k/5.59k [00:00<00:00, 9.88k tasks/s]
Prepare batch: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 31/31 [00:00<00:00, 56.78 samples/s]
compute: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5.59k/5.59k [00:00<00:00, 9.89k tasks/s]
# Validation:   0%|                                                                                                                                                                                                                                       | 0/3 [00:03<?, ?it/s]
[DEBUG] 14:24:49.302 (pyplot.py:switch_backend) -- Loaded backend Agg version v2.2.
Prepare batch: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 31/31 [00:00<00:00, 57.41 samples/s]
compute: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5.59k/5.59k [00:00<00:00, 10.4k tasks/s]
Metrics for 1D are calculated over last 1 elements only. Ignoring 7 predictions per sequence.
# Validation: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:06<00:00,  2.23s/it]
[INFO] 14:24:52.498 (basetrainer.py:train_and_validate) -- Epoch 1 average validation loss: 12.76227 -- Median validation metrics: avg_loss: 12.76227, NSE: -20.70632, KGE: -11.32893
[INFO] 14:24:52.498 (basetrainer.py:train_and_validate) -- learning rate is [0.0005]
Prepare batch: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 256/256 [00:06<00:00, 42.23 samples/s]
# Epoch 2:   0%|                                                                                                                                                                                                                                          | 0/1 [00:06<?, ?it/s]
```