### PR TITLE
Setup mininterval forall tqdm like dask's tqdm.

### DIFF
--- a/googlehydrology/utils/tqdm.py
+++ b/googlehydrology/utils/tqdm.py
@@ -19,6 +19,7 @@ class AutoRefreshTqdm(tqdm):
     """Refresh all other bars on close and when opening a new bar."""
 
     def __init__(self, *args, **kwargs):
+        kwargs['mininterval'] = kwargs.get('mininterval') or 2.0
         super().__init__(*args, **kwargs)
         self.refresh_all()
 


### PR DESCRIPTION
This improves performance. There's no need to immediately update the progress bars, especially when iterations may be 0.5s apart.