### PR TITLE
[optimize memory, runtime] load_caravan_timeseries_together (96% less memory 26gb->1gb, 37% faster 8m->5m)

### DIFF
--- a/googlehydrology/datasetzoo/caravan.py
+++ b/googlehydrology/datasetzoo/caravan.py
@@ -152,8 +152,8 @@ def load_csvs_as_ds(basin_to_path: dict[str, Path]) -> xarray.Dataset:
 _JOIN = functools.partial(
     xarray.combine_nested,
     concat_dim='basin',  # make dim basin to concat by, later assign ids to it
-    coords='minimal',  # share dims (date, basin) of same structure for targets
-    compat='override',  # share same vars' structure (same name same types)
+    coords='minimal',  # share dims structure, it's target features not static
+    compat='override',  # share same variables' nan structure instead of diffing
     combine_attrs='override',  # take metadata eg file modified dates from first
 )
 

--- a/googlehydrology/datasetzoo/caravan.py
+++ b/googlehydrology/datasetzoo/caravan.py
@@ -227,7 +227,7 @@ def load_caravan_timeseries_together(
         start, end = min(starts), max(ends)
         date = pd.date_range(start=start, end=end, freq='D', name='date')
         datasets = [ds.reindex(date=date) for ds in datasets]
-        return _JOIN(datasets, join='override')  # use 1st basin's date
+        return _JOIN(datasets, join='override')  # use 1st basin's date length
 
     def batchify() -> Iterator[xarray.Dataset]:
         batches = map(process_batch, itertools.batched(paths, batch_size))

--- a/googlehydrology/datasetzoo/caravan.py
+++ b/googlehydrology/datasetzoo/caravan.py
@@ -260,8 +260,7 @@ def _load_attribute_files_of_subdatasets(
         df.rename_axis('basin', inplace=True)
         if features:
             df.drop(
-                columns=(e for e in df.columns if e not in features),
-                inplace=True,
+                columns=(e for e in df.columns if e not in features), inplace=True
             )
         return df.to_xarray().chunk(
             'auto'


### PR DESCRIPTION
Optimize 26gb mem over 8min --> 1gb mem over 5min. (16k basins, 46yrs). It's 96% less memory and 37% faster.

`open_mfdataset` actually isn't a C function, isn't optimized for our case. It's general. Combines data with high memory use: 26gb (16k basins over 46yrs).

Looked at its args. Main issue is `join`. It needs to align all 16k data date ranges at once with the general method. However can't just use `join='override'` with open_mfdataset since it would just stack basin date ranges without align.

So, align every 500 basins into a batch that's combined with join 'override' since it's aligned. Now got just 32 combined datasets to combine (for 16k basins) with `join='outer'` which finishes in 100ms and takes ~O(1) memory (some 50 MB or so).

What align means: every basin has data in different parts of years (e.g. a basin on 1980-2020 but another on 1990-2016). So each batch we open all basin datasets and get the first and last dates, so we know min and max of all of those. Now reindex each basin to account for nans at every place where there's a mismatch, so everything is aligned, which is what join='outer' results in.

It could be possible to do something else for the final merge but it's so fast and non memory consuming already, it's better not to micro optimize.

Validated it's the same via `xarray.identical()`. Memory use metered by `psutil.Process(os.getpid()).memory_info().rss/1024**3`.

A side effect is we may progress bars for this phase now.