### PR TITLE
Updated conda environment dependencies for tutorial plotting.

### DIFF
--- a/environments/conda.yml
+++ b/environments/conda.yml
@@ -29,6 +29,7 @@ dependencies:
   - cuda-version=12.4
   - dask
   - gcsfs
+  - geopandas
   - gh
   - h5netcdf
   - h5py
@@ -52,6 +53,7 @@ dependencies:
   - ruamel.yaml
   - ruff
   - scipy
+  - seaborn
   - sphinx
   - sphinx-rtd-theme
   - tensorboard

--- a/environments/rtd_requirements.txt
+++ b/environments/rtd_requirements.txt
@@ -1,3 +1,5 @@
+seaborn
+geopandas
 sphinx>=3.2.1
 sphinx-rtd-theme>=0.5.0
 nbsphinx>=0.8.0


### PR DESCRIPTION
Removed need to pip install tutorial-specific dependencies at the top of the tutorial notebook. 