### PR TITLE
[optimize memory] Compactify indices memory width.

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -584,7 +584,7 @@ class Multimet(Dataset):
         # values are True for a dimension.
         indices = dask.array.nonzero(valid_sample_mask.data)
         # Compact memory widths. Values are indexes within each mask's shape.
-        dtypes = [np.min_scalar_type(n - 1) for n in valid_sample_mask.shape]
+        dtypes = map(np.min_scalar_type, valid_sample_mask.shape)
         indices = tuple(idx.astype(dt) for idx, dt in zip(indices, dtypes))
 
         return valid_sample_mask, indices

--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -583,6 +583,9 @@ class Multimet(Dataset):
         # Each element is a list of valid integer positions (indexers) for which
         # values are True for a dimension.
         indices = dask.array.nonzero(valid_sample_mask.data)
+        # Compact memory widths. Values are indexes within each mask's shape.
+        dtypes = [np.min_scalar_type(n - 1) for n in valid_sample_mask.shape]
+        indices = tuple(idx.astype(dt) for idx, dt in zip(indices, dtypes))
 
         return valid_sample_mask, indices
 

--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -584,8 +584,8 @@ class Multimet(Dataset):
         # values are True for a dimension.
         indices = dask.array.nonzero(valid_sample_mask.data)
         # Compact memory widths. Values are indexes within each mask's shape.
-        dtypes = map(np.min_scalar_type, valid_sample_mask.shape)
-        indices = tuple(idx.astype(dt) for idx, dt in zip(indices, dtypes))
+        min_dtypes = map(np.min_scalar_type, valid_sample_mask.shape)
+        indices = tuple(idx.astype(dt) for idx, dt in zip(indices, min_dtypes))
 
         return valid_sample_mask, indices
 


### PR DESCRIPTION
For example, hundreds of millions up to billions of int64 sample indexes can be stored as uint16 to uint32. So this saves several GBs of memory.

Made sure results' values were the same for several thousands of basins over 40yr.