### PR TITLE
[fix future bug] Set dynamic basin_index vector dtype, not int16.

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -406,8 +406,9 @@ class Multimet(Dataset):
             _ = sample.pop('x_d_forecast')
 
         # Can't use strings. Torch does not support it in tensors.
+        min_dtype = np.min_scalar_type(self._sample_index[item]['basin'])
         sample['basin_index'] = np.array(
-            self._sample_index[item]['basin'], dtype=np.int16
+            self._sample_index[item]['basin'], dtype=min_dtype
         )
 
         return sample


### PR DESCRIPTION
If someone uses more than 2**16 basins with narrow dates, or in the upcoming batchified+lazy mode, this cannot be int16.

I measured np.min_scalar_type performance. It takes 700ns on avg.