### PR TITLE
Avoid numpy warning on conversion of type.

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -411,7 +411,7 @@ class Multimet(Dataset):
         # Can't use strings. Torch does not support it in tensors.
         basin_index = sample_index['basin']
         # Use signed type: -1 handles limits, e.g. 128 > -128 > -129 > int16.
-        min_dtype = np.min_scalar_type(-basin_index  - 1)
+        min_dtype = np.min_scalar_type(-int(basin_index)  - 1)
         sample['basin_index'] = np.array(basin_index , dtype=min_dtype)
 
         return sample


### PR DESCRIPTION
Done via explicit cast to int from the given numpy integer type for basin_index for calculating the min scalar type.

This is to address the repeated numpy warning about it.