### PR TITLE
[opt mem] Reduce mem spikes: MultimetDataLoader::iter keeps only results

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -107,7 +107,10 @@ class MultimetDataLoader(torch.utils.data.DataLoader):
                 {k: _convert_to_tensor(k, v) for k, v in sample.items()}
                 for sample in batch
             ]
-            yield self.collate_fn(batch)
+            batch = self.collate_fn(batch)
+
+            del indices
+            yield batch
 
     def __len__(self):
         return len(self.batch_sampler)


### PR DESCRIPTION
When functions yield, the entire state and stack trace is kept.

There's no need to keep the refs for `batch` nor `indices`. Those aren't used but were thrown away only on a next iteration.