### PR TITLE
Fix state_dict loading for models trained with torch.compile

### DIFF
--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -163,9 +163,16 @@ class BaseTester(object):
         weight_file = self._get_weight_file(epoch)
 
         LOGGER.info(f'Using the model weights from {weight_file}')
-        self.model.load_state_dict(
-            torch.load(weight_file, map_location=self.device, weights_only=True)
+        state_dict = torch.load(
+            weight_file, map_location=self.device, weights_only=True
         )
+        # Drop `_orig_mod.` prefix introduced by torch.compile when the model
+        # was trained with compile=True but is now loaded without compilation.
+        if any(k.startswith('_orig_mod.') for k in state_dict):
+            state_dict = {
+                k[len('_orig_mod.'):]: v for k, v in state_dict.items()
+            }
+        self.model.load_state_dict(state_dict)
 
     def _get_dataset_all(self) -> Dataset:
         """Get dataset for all basins."""


### PR DESCRIPTION
## Problem

When a model is trained with `compile: True` (the current default in
`config.py`), `torch.compile` prepends the `_orig_mod.` prefix to every
parameter key in the saved `state_dict`. Loading those weights into a
non-compiled model fails with a key-mismatch error. This commonly
happens when:

- Running `run evaluate` / `run infer` on a host where `torch.compile`
  is disabled (e.g. Windows without MSVC `cl.exe`).
- Setting `compile: False` in the config for inference while the
  checkpoint was produced with `compile: True`.
- Sharing checkpoints across compiled/non-compiled training runs.

## Fix

In `BaseTester._load_model_weights`, strip the `_orig_mod.` prefix from
all keys before calling `load_state_dict` when its presence is detected.
The check is opt-in (only triggered when the prefix is actually there),
so loading non-compiled weights is unchanged.

## Testing

- Loaded a `compile=True` checkpoint with `compile=False` set in the
  eval config: previously raised `RuntimeError`, now loads cleanly.
- Loaded a `compile=False` checkpoint: behavior unchanged.