### PR TITLE
Fix CSV hindcast schema loading

### DIFF
--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -738,12 +738,30 @@ class Multimet(Dataset):
                 ]
             )
         )
-        return load_caravan_timeseries_together(
+        dataset = load_caravan_timeseries_together(
             data_dir=self._dynamics_data_path,
             basins=self._basins,
             target_features=features,
             csv=True,
         )
+        forecast_origin_features = [
+            feature
+            for feature in self._hindcast_features
+            if feature in self._forecast_features
+        ]
+        plain_features = [
+            feature
+            for feature in features
+            if feature not in forecast_origin_features
+        ]
+        datasets = [dataset[plain_features]]
+        if forecast_origin_features:
+            forecast_origin = dataset[forecast_origin_features].expand_dims(
+                lead_time=[pd.Timedelta(1, unit='D')]
+            )
+            forecast_origin['lead_time'].attrs['units'] = 'timedelta (days)'
+            datasets.append(forecast_origin)
+        return xr.merge(datasets, join='outer')
 
     def _load_forecast_as_csv(self) -> xr.Dataset:
         """Load Caravan-Multimet data for forecast features with file fallback logic.

--- a/googlehydrology/datasetzoo/multimet.py
+++ b/googlehydrology/datasetzoo/multimet.py
@@ -729,21 +729,21 @@ class Multimet(Dataset):
         return product_dss
 
     def _load_hindcast_as_csv(self) -> xr.Dataset:
-        """Load hindcast data and add a 0-day lead_time dimension."""
-        ds = load_caravan_timeseries_together(
+        """Load dimension-faithful hindcasts and union-source features."""
+        features = list(
+            dict.fromkeys(
+                [
+                    *self._hindcast_features,
+                    *(self._union_mapping or {}).values(),
+                ]
+            )
+        )
+        return load_caravan_timeseries_together(
             data_dir=self._dynamics_data_path,
             basins=self._basins,
-            target_features=self._hindcast_features,
+            target_features=features,
             csv=True,
         )
-        
-        # Expand dimensions to include a 0-day lead time coordinate
-        ds = ds.expand_dims(lead_time=[pd.Timedelta(0, unit='D')])
-        
-        # Match the units attribute from the forecast loading logic
-        ds['lead_time'].attrs['units'] = 'timedelta (days)'
-        
-        return ds
 
     def _load_forecast_as_csv(self) -> xr.Dataset:
         """Load Caravan-Multimet data for forecast features with file fallback logic.

--- a/test/test_multimet.py
+++ b/test/test_multimet.py
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-import numpy as np
-import pandas as pd
-import xarray as xr
-import torch
 import re
 from pathlib import Path
-from unittest.mock import patch, MagicMock, call
 from typing import Callable
+from unittest.mock import MagicMock, call, patch
 
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+import xarray as xr
+
+from googlehydrology.datautils.union_features import union_features
 from googlehydrology.datasetzoo.multimet import Multimet
 from googlehydrology.utils.config import Config
-from googlehydrology.utils.errors import NoTrainDataError, NoEvaluationDataError
+from googlehydrology.utils.errors import NoEvaluationDataError, NoTrainDataError
 
 
 # --- Helper for Config attributes ---
@@ -179,6 +181,86 @@ def mock_load_data_return(get_config, sample_basins, sample_dates):
 
 
 # --- Tests for Multimet ---
+
+
+def test_csv_hindcast_loads_union_mapping_sources(tmp_path: Path):
+    dataset = Multimet.__new__(Multimet)
+    dataset._dynamics_data_path = tmp_path
+    dataset._basins = ['basin_01']
+    dataset._hindcast_features = ['cpc_precipitation']
+    dataset._union_mapping = {
+        'cpc_precipitation': 'era5land_total_precipitation'
+    }
+    dates = pd.date_range('2000-01-01', periods=2)
+    loaded = xr.Dataset(
+        {
+            'cpc_precipitation': (
+                ('basin', 'date'),
+                [[np.nan, 2.0]],
+            ),
+            'era5land_total_precipitation': (
+                ('basin', 'date'),
+                [[1.0, 3.0]],
+            ),
+        },
+        coords={'basin': ['basin_01'], 'date': dates},
+    )
+
+    with patch(
+        'googlehydrology.datasetzoo.multimet.'
+        'load_caravan_timeseries_together',
+        return_value=loaded,
+    ) as loader:
+        result = dataset._load_hindcast_as_csv()
+
+    loader.assert_called_once_with(
+        data_dir=tmp_path,
+        basins=['basin_01'],
+        target_features=[
+            'cpc_precipitation',
+            'era5land_total_precipitation',
+        ],
+        csv=True,
+    )
+    unioned = union_features(result, dataset._union_mapping)
+    assert unioned['cpc_precipitation'].values.tolist() == [[1.0, 2.0]]
+
+
+def test_csv_hindcast_does_not_lower_forecast_minimum_lead(tmp_path: Path):
+    dataset = Multimet.__new__(Multimet)
+    dataset._dynamics_data_path = tmp_path
+    dataset._basins = ['basin_01']
+    dataset._hindcast_features = ['hindcast_i1']
+    dataset._union_mapping = {}
+    dates = pd.date_range('2000-01-01', periods=2)
+    loaded = xr.Dataset(
+        {'hindcast_i1': (('basin', 'date'), [[1.0, 2.0]])},
+        coords={'basin': ['basin_01'], 'date': dates},
+    )
+    forecast = xr.Dataset(
+        {
+            'forecast_i1': (
+                ('basin', 'date', 'lead_time'),
+                [[[1.0, 2.0], [3.0, 4.0]]],
+            )
+        },
+        coords={
+            'basin': ['basin_01'],
+            'date': dates,
+            'lead_time': pd.to_timedelta([1, 2], unit='D'),
+        },
+    )
+
+    with patch(
+        'googlehydrology.datasetzoo.multimet.'
+        'load_caravan_timeseries_together',
+        return_value=loaded,
+    ):
+        hindcast = dataset._load_hindcast_as_csv()
+
+    merged = xr.merge([hindcast, forecast], join='outer')
+    assert 'lead_time' not in merged['hindcast_i1'].dims
+    assert merged['lead_time'].min() == pd.Timedelta(days=1)
 
 
 # Patching `Multimet._load_data` because it's a NotImplementedError in the base class

--- a/test/test_multimet.py
+++ b/test/test_multimet.py
@@ -188,6 +188,7 @@ def test_csv_hindcast_loads_union_mapping_sources(tmp_path: Path):
     dataset._dynamics_data_path = tmp_path
     dataset._basins = ['basin_01']
     dataset._hindcast_features = ['cpc_precipitation']
+    dataset._forecast_features = []
     dataset._union_mapping = {
         'cpc_precipitation': 'era5land_total_precipitation'
     }
@@ -226,22 +227,34 @@ def test_csv_hindcast_loads_union_mapping_sources(tmp_path: Path):
     assert unioned['cpc_precipitation'].values.tolist() == [[1.0, 2.0]]
 
 
-def test_csv_hindcast_does_not_lower_forecast_minimum_lead(tmp_path: Path):
+def test_csv_hindcast_preserves_forecast_origin_lead_semantics(
+    tmp_path: Path,
+):
     dataset = Multimet.__new__(Multimet)
     dataset._dynamics_data_path = tmp_path
     dataset._basins = ['basin_01']
-    dataset._hindcast_features = ['hindcast_i1']
+    dataset._hindcast_features = ['cpc_precipitation', 'hres_temperature_2m']
+    dataset._forecast_features = ['hres_temperature_2m']
     dataset._union_mapping = {}
-    dates = pd.date_range('2000-01-01', periods=2)
+    dates = pd.date_range('2000-01-01', periods=4)
     loaded = xr.Dataset(
-        {'hindcast_i1': (('basin', 'date'), [[1.0, 2.0]])},
+        {
+            'cpc_precipitation': (
+                ('basin', 'date'),
+                [[10.0, 20.0, 30.0, 40.0]],
+            ),
+            'hres_temperature_2m': (
+                ('basin', 'date'),
+                [[100.0, 200.0, 300.0, 400.0]],
+            ),
+        },
         coords={'basin': ['basin_01'], 'date': dates},
     )
     forecast = xr.Dataset(
         {
             'forecast_i1': (
                 ('basin', 'date', 'lead_time'),
-                [[[1.0, 2.0], [3.0, 4.0]]],
+                np.ones((1, 4, 2)),
             )
         },
         coords={
@@ -259,8 +272,32 @@ def test_csv_hindcast_does_not_lower_forecast_minimum_lead(tmp_path: Path):
         hindcast = dataset._load_hindcast_as_csv()
 
     merged = xr.merge([hindcast, forecast], join='outer')
-    assert 'lead_time' not in merged['hindcast_i1'].dims
+    assert 'lead_time' not in merged['cpc_precipitation'].dims
+    assert pd.Timedelta(
+        hindcast['hres_temperature_2m']['lead_time'].values[0]
+    ) == pd.Timedelta(days=1)
     assert merged['lead_time'].min() == pd.Timedelta(days=1)
+
+    dataset._dataset = hindcast
+    dataset._data_cache = {}
+    dataset._seq_length = 2
+    dataset._hindcast_features_with_lead_time = ['hres_temperature_2m']
+    dataset._hindcast_features_without_lead_time = ['cpc_precipitation']
+    sample = dataset._extract_hindcasts({'basin': 0, 'date': 2})
+
+    np.testing.assert_array_equal(
+        sample['cpc_precipitation'].squeeze(-1), [20.0, 30.0]
+    )
+    np.testing.assert_array_equal(
+        sample['hres_temperature_2m'].squeeze(-1), [100.0, 200.0]
+    )
+    np.testing.assert_array_equal(
+        dates[[1, 2]], pd.to_datetime(['2000-01-02', '2000-01-03'])
+    )
+    np.testing.assert_array_equal(
+        dates[[0, 1]] + pd.Timedelta(days=1),
+        pd.to_datetime(['2000-01-02', '2000-01-03']),
+    )
 
 
 # Patching `Multimet._load_data` because it's a NotImplementedError in the base class


### PR DESCRIPTION
## Summary
- load `union_mapping` source variables alongside requested CSV hindcast features
- assign lead day 1 to forecast-origin historical inputs that are also configured forecast features
- retain ordinary date-only dimensions for nowcasts, reanalysis, and union-source variables
- verify union completion, forecast minimum lead, and exact historical sample alignment

This is intentionally separate from #264. The implementation now matches the control-basin compatibility shim: HRES/GraphCast-style historical inputs retain lead-day semantics, while CPC/IMERG/ERA5-Land-style inputs do not.

## Test plan
- [x] `/tmp/googlehydrology-venv/bin/pytest -q test/test_multimet.py -k 'csv_hindcast'` (`2 passed`)
- [x] `git diff --check`
- [ ] `/tmp/googlehydrology-venv/bin/pytest -q test/test_multimet.py` (previously `13 passed`, with one existing `test_forecast_dataset_init_success` scaler-call-order failure also present on `main`)