### PR TITLE
Feature: Add 'Hot Start' Inference Support to LSTM Architectures

### DIFF
--- a/example-configs/template_hot_start_config.yml
+++ b/example-configs/template_hot_start_config.yml
@@ -1,0 +1,375 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ==============================================================================
+# GoogleHydrology Configuration File
+# ==============================================================================
+# This YAML file defines all parameters for a training run for the State Handoff
+# Forecast LSTM, which was the operational river forecast model
+# powering the Google FloodHub through 2024. This file represents something that is
+# relatively close to replicating the training settings for the operational model.
+# This is also the model that was used in this paper:
+# 
+#   Nearing, G., et al., (2024) Global prediction of extreme floods in ungauged
+#   watersheds. Nature, 627(8004), 559-563.
+#   https://www.nature.com/articles/s41586-024-07145-1
+#
+# Please note that this is not the codebase that was actually used to train
+# the (old) FloodHub model or the model used in the paper cited above, but
+# it is relatively close.
+
+
+# --- 1. General Experiment Settings -------------------------------------------
+# Basic identifiers and housekeeping for the experiment.
+
+# Unique name for this experiment. Output folders will use this name.
+experiment_name: google-handoff-model
+
+# Directory where model artifacts (weights, config copy, logs) will be saved.
+# IMPORTANT: You must ensure this path exists or can be created.
+run_dir:
+
+# Controls how much information is printed to the console during training.
+# Options: DEBUG, INFO, WARNING, ERROR. 'INFO' is good standard practice.
+logging_level: INFO
+
+# If True, PyTorch will try to find operations that cause NaN or Inf values.
+# Slows down training; usually keep False unless debugging crashes.
+detect_anomaly: False
+
+# If True, warnings (like data storage issues) are only printed once.
+print_warnings_once: True
+
+
+# --- 2. Data Configuration ----------------------------------------------------
+# Defines what data is used, where it comes from, and how it's split.
+
+# Specifies the class of dataset loader to use. 'multimet' is used for Caravan
+# data with multiple meteorological forcing products.
+dataset: multimet
+
+# -- File Paths (UPDATE THESE TO MATCH YOUR SYSTEM) --
+# Paths to text files containing lists of basin IDs for training, validation, and testing.
+train_basin_file: ~/flood-forecasting/example-configs/multimet-basins-list-without-chirps.txt
+validation_basin_file: ~/flood-forecasting/example-configs/multimet-basins-list-without-chirps.txt
+test_basin_file: ~/flood-forecasting/example-configs/multimet-basins-list-without-chirps.txt
+
+# Directory containing the target data (streamflow observations).
+targets_data_dir: Caravan-nc
+# Directory containing static catchment attributes (e.g., area, elevation).
+statics_data_dir: Caravan-nc
+# Directory containing dynamic meteorological forcing data (rain, temp, etc.).
+# 'gs://' indicates data is streamed directly from Google Cloud Storage.
+dynamics_data_dir: gs://caravan-multimet/v1.1
+
+# -- Time Periods --
+# Define the start and end dates for each data split (format: dd/mm/yyyy).
+
+# Training Period: The model learns from data in this date range.
+# It adjusts its internal weights to minimize prediction errors during this time.
+train_start_date: 01/01/1982
+train_end_date: 31/12/2023
+
+# Validation Period: Data in this range is used to check model performance *during* training.
+# It helps prevent overfitting (learning training data too perfectly but failing on new data)
+# and is used to tune hyperparameters like the learning rate.
+validation_start_date: 01/01/1982
+validation_end_date: 31/12/2023
+
+# Test Period: A completely separate period used ONLY after training is finished.
+# It provides the final, unbiased evaluation of how well the model performs on
+# unseen future data.
+test_start_date: 
+test_end_date: 
+
+# -- Input Features (Dynamic) --
+# 'hindcast_inputs': Historical weather data the model sees to learn current state.
+hindcast_inputs:
+  - hres_surface_net_solar_radiation
+  - hres_surface_net_thermal_radiation
+  - hres_surface_pressure
+  - hres_temperature_2m
+  - hres_total_precipitation
+  - imerg_precipitation
+  - cpc_precipitation
+
+# 'forecast_inputs': Future weather data (forecasts) the model uses to predict ahead.
+forecast_inputs:
+  - hres_surface_net_solar_radiation
+  - hres_surface_net_thermal_radiation
+  - hres_surface_pressure
+  - hres_temperature_2m
+  - hres_total_precipitation
+
+# 'union_mapping': Fills missing values (NaNs) in one dataset with values from another.
+# The primary dataset (key) uses data from the fallback dataset (value) to fill gaps.
+# Format: {primary_feature_with_gaps: fallback_feature_to_fill_from}
+union_mapping:
+  cpc_precipitation: era5land_total_precipitation
+  imerg_precipitation: era5land_total_precipitation
+  graphcast_temperature_2m: era5land_temperature_2m
+  graphcast_total_precipitation: era5land_total_precipitation
+  hres_surface_net_solar_radiation: era5land_surface_net_solar_radiation
+  hres_surface_net_thermal_radiation: era5land_surface_net_thermal_radiation
+  hres_surface_pressure: era5land_surface_pressure
+  hres_temperature_2m: era5land_temperature_2m
+  hres_total_precipitation: era5land_total_precipitation
+
+# -- Input Features (Static) --
+# Catchment characteristics that do not change over time.
+static_attributes:
+  - p_mean
+  - pet_mean_ERA5_LAND
+  - aridity_ERA5_LAND
+  - frac_snow
+  - moisture_index_ERA5_LAND
+  - seasonality_ERA5_LAND
+  - high_prec_freq
+  - high_prec_dur
+  - low_prec_freq
+  - low_prec_dur
+  - aet_mm_syr
+  - ari_ix_sav
+  - crp_pc_sse
+  - ele_mt_sav
+  - ero_kh_sav
+  - for_pc_sse
+  - gdp_ud_ssu
+  - gla_pc_sse
+  - glc_pc_s01
+  - glc_pc_s02
+  - glc_pc_s03
+  - glc_pc_s04
+  - glc_pc_s05
+  - glc_pc_s06
+  - glc_pc_s07
+  - glc_pc_s08
+  - glc_pc_s09
+  - glc_pc_s10
+  - glc_pc_s11
+  - glc_pc_s12
+  - glc_pc_s13
+  - glc_pc_s14
+  - glc_pc_s15
+  - glc_pc_s16
+  - glc_pc_s17
+  - glc_pc_s18
+  - glc_pc_s19
+  - glc_pc_s20
+  - glc_pc_s21
+  - glc_pc_s22
+  - hft_ix_s09
+  - hft_ix_s93
+  - inu_pc_slt
+  - inu_pc_smn
+  - inu_pc_smx
+  - ire_pc_sse
+  - kar_pc_sse
+  - lka_pc_sse
+  - nli_ix_sav
+  - pac_pc_sse
+  - pet_mm_syr
+  - pnv_pc_s01
+  - pnv_pc_s02
+  - pnv_pc_s03
+  - pnv_pc_s04
+  - pnv_pc_s05
+  - pnv_pc_s06
+  - pnv_pc_s07
+  - pnv_pc_s08
+  - pnv_pc_s09
+  - pnv_pc_s10
+  - pnv_pc_s11
+  - pnv_pc_s12
+  - pnv_pc_s13
+  - pnv_pc_s14
+  - pnv_pc_s15
+  - ppd_pk_sav
+  - pre_mm_syr
+  - prm_pc_sse
+  - rdd_mk_sav
+  - snw_pc_syr
+  - swc_pc_syr
+  - tmp_dc_syr
+  - urb_pc_sse
+  - wet_pc_s01
+  - wet_pc_s02
+  - wet_pc_s03
+  - wet_pc_s04
+  - wet_pc_s05
+  - wet_pc_s06
+  - wet_pc_s07
+  - wet_pc_s08
+  - wet_pc_s09
+  - wet_pc_sg1
+  - wet_pc_sg2 
+
+# -- Targets --
+# The variable(s) we are trying to predict.
+target_variables:
+- streamflow
+
+
+# --- 3. Model Architecture ----------------------------------------------------
+# Defines the structure of the neural network.
+
+# The specific model class to use from the model zoo.
+# 'handoff_forecast_lstm' uses separate LSTMs for past and future with a
+# state-handoff network between them.
+model: handoff_forecast_lstm
+
+# Size of the hidden state vector in the LSTM layers. Higher = more capacity but
+# higher risk of overfitting.
+hidden_size: 256
+
+# These CMAL settings come from https://hess.copernicus.org/articles/26/1673/2022
+head: cmal
+n_distributions: 3
+n_samples: 7500
+negative_sample_handling: clip
+
+# Number of days of past data the model uses as input for a single prediction.
+seq_length: 0
+hot_start_path:
+
+# Number of days into the future to predict.
+lead_time: 7
+
+# Number of days the hindcast (past) and forecast (future) LSTMs overlap.
+forecast_overlap: 10
+
+# If True, adds a feature indicating how many days ahead the forecast is for.
+timestep_counter: True
+
+# -- Dropout --
+# Regularization technique to prevent overfitting.
+output_dropout: 0.4    # Fraction of neurons to randomly deactivate in the output layer.
+
+# -- Initialization --
+# Sets initial values for model weights before training starts.
+initial_forget_bias: 3 # High initial forget gate bias helps LSTMs learn long-term dependencies.
+weight_init_opts:      # specific initialization schemes for different parts of the network.
+- lstm-ih-xavier
+- lstm-hh-orthogonal
+- fc-xavier
+
+# -- Sub-network Configurations --
+# Architectures for the small feed-forward networks that process specific input types
+# before they go into the main LSTMs.
+statics_embedding:
+  type: fc                         # Fully Connected (dense) network
+  hiddens: [100, 100, 20]          # Three layers with 100, 100, and 20 neurons each
+  activation: [tanh, tanh, linear] # Activation functions for each layer
+  dropout: 0.0
+
+# We did not use hindcast and forecast embedding layers.
+hindcast_embedding:
+forecast_embedding:
+
+# Architecture for the network that transforms the final hindcast state
+# (LSTM cell state and hidden state) into the initial forecast state.
+state_handoff_network:
+  type: fc
+  activation: [tanh]
+  dropout: 0.0
+  hiddens: [128]
+
+# --- 4. Training Configuration ------------------------------------------------
+# Controls how the model learns from data.
+
+# Choose which GPU to run the code with. On most systems you can see the
+# available GPUs using `nvidia-smi`. The most common naming scheme for GPUs
+# is `cuda:0`, 'cuda:1`, etc.
+# Set this argument to `cpu` for training on a CPU
+device: cuda:0
+
+# The optimization algorithm. Adam is a standard, robust choice.
+optimizer: Adam
+
+# The loss function to minimize during training. 
+loss: cmalloss
+
+# -- Training Loop --
+# Number of times the model sees the entire training dataset.
+epochs: 50
+
+# Number of samples processed at once before updating weights.
+batch_size: 256
+
+# Maximum number of weight updates per epoch (useful for very large datasets).
+max_updates_per_epoch: 2000
+
+# -- Learning Rate Scheduler --
+# Adjusts the learning rate during training to improve convergence.
+learning_rate_strategy: ReduceLROnPlateau # Lowers LR when validation loss stops improving.
+initial_learning_rate: 0.001              # Starting step size for weight updates.
+learning_rate_drop_factor: 0.5            # Multiply LR by this when dropping (unused).
+learning_rate_epochs_drop: 10             # Epochs between learning rate drops.
+
+# -- Regularization & Stability --
+# Prevents exploding gradients which can destabilize training.
+clip_gradient_norm: 1
+
+# Adds small random noise to targets during training to improve robustness.
+target_noise_std: 0.005
+
+# --- 5. Validation & Evaluation -----------------------------------------------
+# Settings for checking model performance during and after training.
+
+# Metrics to calculate during validation and print to the console.
+metrics:
+- NSE       # Nash-Sutcliffe Efficiency (standard hydrology metric, 1=perfect, <0=worse than mean).
+- KGE       # Kling-Gupta Efficiency (balances correlation, variability error, and bias error. 1=perfect).
+#- Alpha-NSE # Variability ratio (std_sim / std_obs). Ideal value is 1.
+#- Beta-NSE  # Standardized bias ( (mean_sim - mean_obs) / std_obs ). Ideal value is 0.
+#- Beta-KGE  # Bias ratio (mean_sim / mean_obs). Ideal value is 1.
+#- Pearson-r # Pearson correlation coefficient. Measures timing/shape agreement only. Ideal value is 1.
+
+# How often (in epochs) to run validation.
+validate_every: 1
+
+# Number of basins to use for validation. -1 means use ALL validation basins.
+validate_n_random_basins: -1
+
+# During testing/validation, ignore periods where observations are completely missing.
+tester_skip_obs_all_nan: True
+
+# Method for aggregating multiple predictions if ensemble is used (median is robust).
+tester_sample_reduction: median
+
+# Forces negative predictions to zero for these variables (physically realistic for streamflow).
+clip_targets_to_zero:
+- streamflow
+
+# Defines which time steps are used to calculate loss. 8 means only the last 8 days
+# of the sequence contributes to the error (focuses model on the forecast period).
+predict_last_n: 8
+
+# If True, samples with all-zero inputs are treated as invalid data gaps.
+allzero_samples_are_invalid: False
+
+
+# --- 6. System & Runtime ------------------------------------------------------
+# Computational settings.
+
+# Number of CPU processes used to load data in parallel. Higher can be faster.
+num_workers: 0
+# How often to print training loss to Tensorboard.
+log_loss_every_nth_update: 50
+
+# Data caching settings to speed up training by keeping data in RAM.
+cache:
+  enabled: False          # Set to True if you have enough RAM (~250GB for Caravan).
+  byte_limit: 10000000000 # Max RAM to use for cache (in bytes, ~10GB here)
+

--- a/googlehydrology/datautils/validate_samples.py
+++ b/googlehydrology/datautils/validate_samples.py
@@ -405,6 +405,9 @@ def validate_sequence_all(
     """
     mask = mask.fillna(False)
 
+    if seq_length <= 0:
+        return xr.full_like(mask, True, dtype=bool)
+
     # The sliding window is valid if ALL timestemps are True which is what
     # min represents in the window being True (1).
     valid_windows = mask.rolling(date=seq_length, min_periods=seq_length).min()
@@ -446,6 +449,9 @@ def validate_sequence_any(
         Boolean valid sample mask.
     """
     mask = mask.fillna(False)
+
+    if seq_length <= 0:
+        return xr.full_like(mask, True, dtype=bool)
 
     # The sliding window is valid if ANY timestemp is True which is what
     # max represents in the window being True (1).

--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -92,6 +92,13 @@ class BaseTester(object):
                 f'Invalid period {period}. Must be one of ["train", "validation", "test"]'
             )
 
+        if getattr(self.cfg, 'hot_start_path', None) is not None:
+            if self.cfg.batch_size != 1:
+                raise ValueError(
+                    f'Hot-start inference requires batch_size=1 per basin. '
+                    f'Got batch_size={self.cfg.batch_size}.'
+                )
+
         # determine device
         self._set_device()
 
@@ -659,13 +666,27 @@ class BaseTester(object):
                 if basin not in basins:
                     continue
 
+                # Pre-load hot-start state for this basin if configured
+                if getattr(self.cfg, 'hot_start_path', None) is not None:
+                    state_path = self.cfg.hot_start_path
+                    if state_path.is_dir():
+                        basin_state = state_path / f'state_{basin}.npz'
+                        if not basin_state.exists():
+                            basin_state = state_path / f'{basin}.npz'
+                    else:
+                        basin_state = state_path
+                    if basin_state.exists():
+                        model.load_state_from_disk(basin_state)
+
                 preds = {}
                 obs = {}
                 dates = {}
                 losses = []
                 mean_losses = {}
+                last_data = None
 
                 for data in samples:
+                    last_data = data
                     for key in data:
                         if key.startswith('x_d'):
                             data[key] = {
@@ -711,6 +732,17 @@ class BaseTester(object):
                             )
 
                     losses.append(loss)
+
+                # Save hot-start state for this basin if configured
+                if (
+                    getattr(self.cfg, 'save_state', False)
+                    and last_data is not None
+                    and not self.cfg.is_train
+                ):
+                    save_dir = self.run_dir / 'hot_start_states'
+                    save_dir.mkdir(parents=True, exist_ok=True)
+                    state_save_path = save_dir / f'state_{basin}.npz'
+                    model.save_state(last_data, state_save_path)
 
                 # set to NaN explicitly if all losses are NaN to avoid RuntimeWarning
                 if len(losses) == 0:

--- a/googlehydrology/evaluation/tester.py
+++ b/googlehydrology/evaluation/tester.py
@@ -666,6 +666,7 @@ class BaseTester(object):
                 if basin not in basins:
                     continue
 
+                model.reset_state()
                 # Pre-load hot-start state for this basin if configured
                 if getattr(self.cfg, 'hot_start_path', None) is not None:
                     state_path = self.cfg.hot_start_path

--- a/googlehydrology/modelzoo/basemodel.py
+++ b/googlehydrology/modelzoo/basemodel.py
@@ -108,6 +108,8 @@ class BaseModel(nn.Module):
     ) -> None:
         """Save the hot start state of the model.
 
+        Default implementation is a no-op for models that do not support state persistence.
+
         Parameters
         ----------
         data : dict[str, torch.Tensor | dict[str, torch.Tensor]]
@@ -115,17 +117,23 @@ class BaseModel(nn.Module):
         path : str | Path
             The file path where the state should be saved (npz recommended).
         """
-        raise NotImplementedError
+        pass
 
     def load_state_from_disk(self, path: str | Path) -> None:
         """Pre-load a hot start state archive from disk into memory.
 
+        Default implementation is a no-op for models that do not support state persistence.
+
         Parameters
         ----------
         path : str | Path
-            Path to the .npz state file to load.
+            Path to the state file to load.
         """
-        self._preloaded_state = dict(np.load(path, allow_pickle=False))
+        pass
+
+    def reset_state(self) -> None:
+        """Reset in-memory hot-start state between basins."""
+        self._preloaded_state = None
 
     def pre_model_hook(
         self, data: dict[str, torch.Tensor], is_train: bool

--- a/googlehydrology/modelzoo/basemodel.py
+++ b/googlehydrology/modelzoo/basemodel.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from pathlib import Path
+
+import numpy as np
 import torch
 import torch.nn as nn
 
@@ -47,6 +50,7 @@ class BaseModel(nn.Module):
             scaler_dir=(cfg.base_run_dir if cfg.is_finetuning else cfg.run_dir),
             calculate_scaler=False,
         )
+        self._preloaded_state = None
 
     def sample(
         self,
@@ -96,6 +100,32 @@ class BaseModel(nn.Module):
             Model output and potentially any intermediate states and activations as a dictionary.
         """
         raise NotImplementedError
+
+    def save_state(
+        self,
+        data: dict[str, torch.Tensor | dict[str, torch.Tensor]],
+        path: str | Path,
+    ) -> None:
+        """Save the hot start state of the model.
+
+        Parameters
+        ----------
+        data : dict[str, torch.Tensor | dict[str, torch.Tensor]]
+            Dictionary containing input features as key-value pairs.
+        path : str | Path
+            The file path where the state should be saved (npz recommended).
+        """
+        raise NotImplementedError
+
+    def load_state_from_disk(self, path: str | Path) -> None:
+        """Pre-load a hot start state archive from disk into memory.
+
+        Parameters
+        ----------
+        path : str | Path
+            Path to the .npz state file to load.
+        """
+        self._preloaded_state = dict(np.load(path, allow_pickle=False))
 
     def pre_model_hook(
         self, data: dict[str, torch.Tensor], is_train: bool

--- a/googlehydrology/modelzoo/handoff_forecast_lstm.py
+++ b/googlehydrology/modelzoo/handoff_forecast_lstm.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
+import numpy as np
 import torch
 import torch.nn as nn
 
@@ -274,23 +277,139 @@ class HandoffForecastLSTM(BaseModel):
         # Run the hindcast LSTM. This happens in two parts. First, the true hindcast
         # or spin-up, then the part the overlaps with the forecast. This is necessary
         # to extract the hidden and cell states at the point of the handoff.
-        spinup_embeddings = hindcast_embeddings[:, : -self.overlap,]
-        overlap_embeddings = hindcast_embeddings[:, -self.overlap :,]
-        spinup, (h_hindcast, c_hindcast) = self.hindcast_lstm(spinup_embeddings)
-        hindcast_overlap, _ = self.hindcast_lstm(
-            overlap_embeddings, (h_hindcast, c_hindcast)
-        )
+        state = getattr(self, '_preloaded_state', None)
+        if state is None:
+            hot_start_path = getattr(self.cfg, 'hot_start_path', None)
+            if hot_start_path is not None and Path(hot_start_path).is_file():
+                state = dict(np.load(hot_start_path, allow_pickle=False))
 
-        # Handoff from hindcast to forecast.
-        x = self.handoff_net(torch.cat([h_hindcast, c_hindcast], -1))
-        initial_state = self.handoff_linear(x)
-        h_handoff, c_handoff = initial_state.chunk(2, -1)
-        h_handoff, c_handoff = h_handoff.contiguous(), c_handoff.contiguous()
+        hindcast_initial_state = None
+        forecast_initial_state = None
+        is_hot_start = False
+        if state is not None:
+            device = forecast_embeddings.device
+            dtype = forecast_embeddings.dtype
+            h_hindcast = torch.from_numpy(state['h_hindcast']).to(
+                device=device, dtype=dtype
+            )
+            c_hindcast = torch.from_numpy(state['c_hindcast']).to(
+                device=device, dtype=dtype
+            )
+            hindcast_initial_state = (h_hindcast, c_hindcast)
+
+            # For MeanEmbedding or models that preserve both
+            if 'h_forecast' in state:
+                h_forecast = torch.from_numpy(state['h_forecast']).to(
+                    device=device, dtype=dtype
+                )
+                c_forecast = torch.from_numpy(state['c_forecast']).to(
+                    device=device, dtype=dtype
+                )
+                forecast_initial_state = (h_forecast, c_forecast)
+
+            # Even if overlap is > 0, if seq_length == 0 on a hot start we have 0
+            # hindcast elements. We flag this so we can bypass spinup processing.
+            if hindcast_embeddings.size(1) == 0:
+                is_hot_start = True
+
+        if is_hot_start:
+            # Bypass spinup entirely. We shouldn't run hindcast_lstm on 0-length inputs.
+            # Spinup and hindcast_overlap outputs are empty for a length-0 hot start.
+            spinup = torch.empty(
+                hindcast_embeddings.size(0),
+                0,
+                self.hindcast_hidden_size,
+                device=hindcast_embeddings.device,
+            )
+            hindcast_overlap = torch.empty(
+                hindcast_embeddings.size(0),
+                0,
+                self.hindcast_hidden_size,
+                device=hindcast_embeddings.device,
+            )
+
+            # The initial state is already at the correct temporal index (end of
+            # historical overlap).
+            h_handoff, c_handoff = forecast_initial_state
+            if forecast_embeddings.size(1) > self.lead_time:
+                forecast_embeddings = forecast_embeddings[
+                    :, -self.lead_time :, :
+                ]
+        else:
+            # Normal cold-start or save-state propagation
+            if self.overlap > 0:
+                spinup_embeddings = hindcast_embeddings[:, : -self.overlap]
+                overlap_embeddings = hindcast_embeddings[:, -self.overlap :]
+            else:
+                spinup_embeddings = hindcast_embeddings
+                overlap_embeddings = hindcast_embeddings[:, 0:0, :]
+
+            if spinup_embeddings.size(1) > 0:
+                if hindcast_initial_state is not None:
+                    spinup, (h_hindcast, c_hindcast) = self.hindcast_lstm(
+                        spinup_embeddings, hindcast_initial_state
+                    )
+                else:
+                    spinup, (h_hindcast, c_hindcast) = self.hindcast_lstm(
+                        spinup_embeddings
+                    )
+            else:
+                spinup = torch.empty(
+                    hindcast_embeddings.size(0),
+                    0,
+                    self.hindcast_hidden_size,
+                    device=hindcast_embeddings.device,
+                )
+                # If spinup is length 0 but overlap > 0, we use loaded initial state
+                if hindcast_initial_state is not None:
+                    h_hindcast, c_hindcast = hindcast_initial_state
+                else:
+                    h_hindcast = torch.zeros(
+                        1,
+                        hindcast_embeddings.size(0),
+                        self.hindcast_hidden_size,
+                        device=hindcast_embeddings.device,
+                    )
+                    c_hindcast = torch.zeros(
+                        1,
+                        hindcast_embeddings.size(0),
+                        self.hindcast_hidden_size,
+                        device=hindcast_embeddings.device,
+                    )
+
+            if overlap_embeddings.size(1) > 0:
+                hindcast_overlap, (h_hind_final, c_hind_final) = (
+                    self.hindcast_lstm(
+                        overlap_embeddings, (h_hindcast, c_hindcast)
+                    )
+                )
+            else:
+                hindcast_overlap = torch.empty(
+                    hindcast_embeddings.size(0),
+                    0,
+                    self.hindcast_hidden_size,
+                    device=hindcast_embeddings.device,
+                )
+                h_hind_final, c_hind_final = h_hindcast, c_hindcast
+
+            # Handoff from hindcast to forecast.
+            x = self.handoff_net(torch.cat([h_hindcast, c_hindcast], -1))
+            initial_state = self.handoff_linear(x)
+            h_handoff, c_handoff = initial_state.chunk(2, -1)
+            h_handoff, c_handoff = (
+                h_handoff.contiguous(),
+                c_handoff.contiguous(),
+            )
 
         # Run the forecast LSTM.
+        # If hot start, forecast_embeddings is just the lead_time (no overlap),
+        # so we just run it directly on the state.
+        # But if it's cold start, forecast_embeddings has overlap + lead_time,
+        # and runs from the h_handoff (which is from BEFORE overlap).
         forecast, _ = self.forecast_lstm(
             forecast_embeddings, (h_handoff, c_handoff)
         )
+
 
         # Run head layers.
         y_spinup = self.hindcast_head(self.dropout(spinup))
@@ -305,7 +424,8 @@ class HandoffForecastLSTM(BaseModel):
                     y_hindcast_overlap[key], 
                     y_forecast[key][:, -self.lead_time :, :]
                 ], dim=1
-            )[:, -self.seq_length :, :] for key in y_spinup
+            )
+            for key in y_forecast
         }
         
         if self.overlap_output:
@@ -319,3 +439,112 @@ class HandoffForecastLSTM(BaseModel):
 
         return output
 
+    @torch.no_grad()
+    def save_state(
+        self,
+        data: dict[str, torch.Tensor | dict[str, torch.Tensor]],
+        path: str | Path,
+    ) -> None:
+        """Perform a partial forward pass and save state for a hot start at path.
+
+        Parameters
+        ----------
+        data : dict[str, torch.Tensor | dict[str, torch.Tensor]]
+            Dictionary containing input features as key-value pairs.
+        path : str | Path
+            The file path where the state should be saved (.npz format).
+        """
+        # Run the embedding layers.
+        hindcast_features = torch.cat(
+            [
+                t
+                for f, t in data['x_d_hindcast'].items()
+                if f in self.hindcast_inputs
+            ],
+            dim=-1,
+        )
+
+        statics_embeddings = self.statics_embedding_net(data['x_s'])
+        hindcast_embeddings = self.hindcast_embedding_net(hindcast_features)
+
+        hindcast_embeddings = torch.cat(
+            [
+                hindcast_embeddings,
+                statics_embeddings.unsqueeze(1).expand(
+                    -1, hindcast_embeddings.size(1), -1
+                ),
+            ],
+            dim=-1,
+        )
+
+        # We run the exact same logic up to the final temporal state (Day D)
+        forecast_features = torch.cat(
+            [
+                t
+                for f, t in data['x_d_forecast'].items()
+                if f in self.forecast_inputs
+            ],
+            dim=-1,
+        )
+
+        forecast_embeddings = self.forecast_embedding_net(forecast_features)
+        forecast_embeddings = torch.cat(
+            [
+                forecast_embeddings,
+                statics_embeddings.unsqueeze(1).expand(
+                    -1, forecast_embeddings.size(1), -1
+                ),
+            ],
+            dim=-1,
+        )
+
+        # Cold start logic internally to propagate up to Day D
+        if self.overlap > 0:
+            spinup_embeddings = hindcast_embeddings[:, : -self.overlap]
+            overlap_embeddings_hindcast = hindcast_embeddings[
+                :, -self.overlap :
+            ]
+
+            # Forecast embeddings contains overlap+lead. We only want overlap.
+            overlap_embeddings_forecast = forecast_embeddings[
+                :, : self.overlap, :
+            ]
+        else:
+            spinup_embeddings = hindcast_embeddings
+            overlap_embeddings_hindcast = hindcast_embeddings[:, 0:0, :]
+            overlap_embeddings_forecast = forecast_embeddings[:, 0:0, :]
+
+        _, (h_hindcast, c_hindcast) = self.hindcast_lstm(spinup_embeddings)
+
+        # We also run hindcast overlap to save its final state
+        if overlap_embeddings_hindcast.size(1) > 0:
+            _, (h_hind_final, c_hind_final) = self.hindcast_lstm(
+                overlap_embeddings_hindcast, (h_hindcast, c_hindcast)
+            )
+        else:
+            h_hind_final, c_hind_final = h_hindcast, c_hindcast
+
+        # Handoff
+        x = self.handoff_net(torch.cat([h_hindcast, c_hindcast], -1))
+        initial_state = self.handoff_linear(x)
+        h_handoff, c_handoff = initial_state.chunk(2, -1)
+        h_handoff, c_handoff = (
+            h_handoff.contiguous(),
+            c_handoff.contiguous(),
+        )
+
+        # Run forecast lstm on just the overlap
+        if overlap_embeddings_forecast.size(1) > 0:
+            _, (h_fore_final, c_fore_final) = self.forecast_lstm(
+                overlap_embeddings_forecast, (h_handoff, c_handoff)
+            )
+        else:
+            h_fore_final, c_fore_final = h_handoff, c_handoff
+
+        np.savez_compressed(
+            path,
+            h_hindcast=h_hind_final.detach().cpu().numpy(),
+            c_hindcast=c_hind_final.detach().cpu().numpy(),
+            h_forecast=h_fore_final.detach().cpu().numpy(),
+            c_forecast=c_fore_final.detach().cpu().numpy(),
+        )

--- a/googlehydrology/modelzoo/handoff_forecast_lstm.py
+++ b/googlehydrology/modelzoo/handoff_forecast_lstm.py
@@ -276,36 +276,34 @@ class HandoffForecastLSTM(BaseModel):
         
         # Run the hindcast LSTM. This happens in two parts. First, the true hindcast
         # or spin-up, then the part the overlaps with the forecast. This is necessary
-        # to extract the hidden and cell states at the point of the handoff.
         state = getattr(self, '_preloaded_state', None)
-        if state is None:
-            hot_start_path = getattr(self.cfg, 'hot_start_path', None)
-            if hot_start_path is not None and Path(hot_start_path).is_file():
-                state = dict(np.load(hot_start_path, allow_pickle=False))
-
         hindcast_initial_state = None
         forecast_initial_state = None
         is_hot_start = False
         if state is not None:
             device = forecast_embeddings.device
             dtype = forecast_embeddings.dtype
-            h_hindcast = torch.from_numpy(state['h_hindcast']).to(
-                device=device, dtype=dtype
-            )
-            c_hindcast = torch.from_numpy(state['c_hindcast']).to(
-                device=device, dtype=dtype
-            )
-            hindcast_initial_state = (h_hindcast, c_hindcast)
+            h_hind_arr = state.get('h_hindcast', state.get('h_hind'))
+            c_hind_arr = state.get('c_hindcast', state.get('c_hind'))
+            h_fore_arr = state.get('h_forecast', state.get('h_fore'))
+            c_fore_arr = state.get('c_forecast', state.get('c_fore'))
 
-            # For MeanEmbedding or models that preserve both
-            if 'h_forecast' in state:
-                h_forecast = torch.from_numpy(state['h_forecast']).to(
-                    device=device, dtype=dtype
+            def _to_3d_tensor(arr):
+                t = torch.from_numpy(arr).to(device=device, dtype=dtype)
+                while t.ndim < 3:
+                    t = t.unsqueeze(0)
+                return t
+
+            if h_hind_arr is not None and c_hind_arr is not None:
+                hindcast_initial_state = (
+                    _to_3d_tensor(h_hind_arr),
+                    _to_3d_tensor(c_hind_arr),
                 )
-                c_forecast = torch.from_numpy(state['c_forecast']).to(
-                    device=device, dtype=dtype
+            if h_fore_arr is not None and c_fore_arr is not None:
+                forecast_initial_state = (
+                    _to_3d_tensor(h_fore_arr),
+                    _to_3d_tensor(c_fore_arr),
                 )
-                forecast_initial_state = (h_forecast, c_forecast)
 
             # Even if overlap is > 0, if seq_length == 0 on a hot start we have 0
             # hindcast elements. We flag this so we can bypass spinup processing.
@@ -424,7 +422,7 @@ class HandoffForecastLSTM(BaseModel):
                     y_hindcast_overlap[key], 
                     y_forecast[key][:, -self.lead_time :, :]
                 ], dim=1
-            )
+            )[:, -self.seq_length :, :]
             for key in y_forecast
         }
         
@@ -548,3 +546,13 @@ class HandoffForecastLSTM(BaseModel):
             h_forecast=h_fore_final.detach().cpu().numpy(),
             c_forecast=c_fore_final.detach().cpu().numpy(),
         )
+
+    def load_state_from_disk(self, path: str | Path) -> None:
+        """Pre-load a hot start state archive from disk into memory.
+
+        Parameters
+        ----------
+        path : str | Path
+            Path to the .npz state file to load.
+        """
+        self._preloaded_state = dict(np.load(path, allow_pickle=False))

--- a/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
+++ b/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import dataclasses
+from pathlib import Path
 from typing import Iterable
 
 import numpy as np
@@ -244,23 +245,125 @@ class MeanEmbeddingForecastLSTM(BaseModel):
             for name, fc in self.shared_embeddings_fc.items()
         ]
 
+        state = getattr(self, '_preloaded_state', None)
+        if state is None:
+            hot_start_path = getattr(self.cfg, 'hot_start_path', None)
+            if hot_start_path is not None and Path(hot_start_path).is_file():
+                state = dict(np.load(hot_start_path, allow_pickle=False))
+
+        h_hind_init = None
+        h_fore_init = None
+        if state is not None:
+            device = static_embedding.device
+            dtype = static_embedding.dtype
+            h_hind_init = (
+                torch.from_numpy(state['h_hindcast']).to(
+                    device=device, dtype=dtype
+                ),
+                torch.from_numpy(state['c_hindcast']).to(
+                    device=device, dtype=dtype
+                ),
+            )
+            h_fore_init = (
+                torch.from_numpy(state['h_forecast']).to(
+                    device=device, dtype=dtype
+                ),
+                torch.from_numpy(state['c_forecast']).to(
+                    device=device, dtype=dtype
+                ),
+            )
+
+
         hindcast_state = self._calc_lstm(
             lstm=self.hindcast_lstm,
             embeddings=hindcast_embeddings + shared_embeddings,
             static_embedding=static_embedding,
+            initial_state=h_hind_init,
         )
         forecast_state = self._calc_lstm(
             lstm=self.forecast_lstm,
             embeddings=forecast_embeddings + shared_embeddings,
             static_embedding=static_embedding,
             other_inputs=hindcast_state,
+            initial_state=h_fore_init,
         )
 
         head = self._calc_head(forecast_state)
+        
 
         return head
 
+    @torch.no_grad()
+    def save_state(
+        self,
+        data: dict[str, torch.Tensor | dict[str, torch.Tensor]],
+        path: str | Path,
+    ) -> None:
+        """Perform a partial forward pass and save state for a hot start at path.
+
+        Parameters
+        ----------
+        data : dict[str, torch.Tensor | dict[str, torch.Tensor]]
+            Dictionary containing input features as key-value pairs.
+        path : str | Path
+            The file path where the state should be saved (.npz format).
+        """
+        forward_data = ForwardData.from_forward_data(data, self.config_data)
+
+        static_embedding = self._calc_static_embedding(forward_data)
+
+        hindcast_embeddings = [
+            self._calc_dynamic_embedding(
+                embedding_network=fc,
+                dynamic_data=forward_data.hindcast_features[name],
+                static_embedding=static_embedding,
+                append_nan=True,
+            )[:, : self.seq_length, :]
+            for name, fc in self.hindcast_embeddings_fc.items()
+        ]
+        forecast_embeddings = [
+            self._calc_dynamic_embedding(
+                embedding_network=fc,
+                dynamic_data=forward_data.forecast_features[name],
+                static_embedding=static_embedding,
+                append_nan=False,
+            )[:, : self.seq_length, :]
+            for name, fc in self.forecast_embeddings_fc.items()
+        ]
+        shared_embeddings = [
+            self._calc_dynamic_embedding(
+                embedding_network=fc,
+                dynamic_data=forward_data.forecast_features[name],
+                static_embedding=static_embedding,
+                append_nan=False,
+            )[:, : self.seq_length, :]
+            for name, fc in self.shared_embeddings_fc.items()
+        ]
+
+        hindcast_state, (h_hind, c_hind) = self._calc_lstm(
+            lstm=self.hindcast_lstm,
+            embeddings=hindcast_embeddings + shared_embeddings,
+            static_embedding=static_embedding,
+            return_state=True,
+        )
+        forecast_state, (h_fore, c_fore) = self._calc_lstm(
+            lstm=self.forecast_lstm,
+            embeddings=forecast_embeddings + shared_embeddings,
+            static_embedding=static_embedding,
+            other_inputs=hindcast_state,
+            return_state=True,
+        )
+
+        np.savez_compressed(
+            path,
+            h_hindcast=h_hind.detach().cpu().numpy(),
+            c_hindcast=c_hind.detach().cpu().numpy(),
+            h_forecast=h_fore.detach().cpu().numpy(),
+            c_forecast=c_fore.detach().cpu().numpy(),
+        )
+
     def _make_static_embedding_repeated(
+
         self, time_length: int, static_embedding: torch.Tensor
     ) -> torch.Tensor:
         """Returns the attributes repeated w.r.t the time length."""
@@ -338,7 +441,9 @@ class MeanEmbeddingForecastLSTM(BaseModel):
         embeddings: Iterable[torch.Tensor],
         static_embedding: torch.Tensor,
         other_inputs: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        initial_state: tuple[torch.Tensor, torch.Tensor] | None = None,
+        return_state: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
         masked_mean_embeddings = self._masked_mean(embeddings)
         if other_inputs is not None:
             masked_mean_embeddings = torch.cat(
@@ -347,8 +452,14 @@ class MeanEmbeddingForecastLSTM(BaseModel):
         lstm_inputs = self._append_static_embedding(
             masked_mean_embeddings, static_embedding
         )
-        output, _ = lstm(input=lstm_inputs)
+        if initial_state is not None:
+            output, hx = lstm(input=lstm_inputs, hx=initial_state)
+        else:
+            output, hx = lstm(input=lstm_inputs)
+        if return_state:
+            return output, hx
         return output
+
 
     def _calc_head(
         self, forecast_state: torch.Tensor

--- a/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
+++ b/googlehydrology/modelzoo/mean_embedding_forecast_lstm.py
@@ -246,32 +246,32 @@ class MeanEmbeddingForecastLSTM(BaseModel):
         ]
 
         state = getattr(self, '_preloaded_state', None)
-        if state is None:
-            hot_start_path = getattr(self.cfg, 'hot_start_path', None)
-            if hot_start_path is not None and Path(hot_start_path).is_file():
-                state = dict(np.load(hot_start_path, allow_pickle=False))
-
         h_hind_init = None
         h_fore_init = None
         if state is not None:
             device = static_embedding.device
             dtype = static_embedding.dtype
-            h_hind_init = (
-                torch.from_numpy(state['h_hindcast']).to(
-                    device=device, dtype=dtype
-                ),
-                torch.from_numpy(state['c_hindcast']).to(
-                    device=device, dtype=dtype
-                ),
-            )
-            h_fore_init = (
-                torch.from_numpy(state['h_forecast']).to(
-                    device=device, dtype=dtype
-                ),
-                torch.from_numpy(state['c_forecast']).to(
-                    device=device, dtype=dtype
-                ),
-            )
+            h_hind_arr = state.get('h_hindcast', state.get('h_hind'))
+            c_hind_arr = state.get('c_hindcast', state.get('c_hind'))
+            h_fore_arr = state.get('h_forecast', state.get('h_fore'))
+            c_fore_arr = state.get('c_forecast', state.get('c_fore'))
+
+            def _to_3d_tensor(arr):
+                t = torch.from_numpy(arr).to(device=device, dtype=dtype)
+                while t.ndim < 3:
+                    t = t.unsqueeze(0)
+                return t
+
+            if h_hind_arr is not None and c_hind_arr is not None:
+                h_hind_init = (
+                    _to_3d_tensor(h_hind_arr),
+                    _to_3d_tensor(c_hind_arr),
+                )
+            if h_fore_arr is not None and c_fore_arr is not None:
+                h_fore_init = (
+                    _to_3d_tensor(h_fore_arr),
+                    _to_3d_tensor(c_fore_arr),
+                )
 
 
         hindcast_state = self._calc_lstm(
@@ -361,6 +361,16 @@ class MeanEmbeddingForecastLSTM(BaseModel):
             h_forecast=h_fore.detach().cpu().numpy(),
             c_forecast=c_fore.detach().cpu().numpy(),
         )
+
+    def load_state_from_disk(self, path: str | Path) -> None:
+        """Pre-load a hot start state archive from disk into memory.
+
+        Parameters
+        ----------
+        path : str | Path
+            Path to the .npz state file to load.
+        """
+        self._preloaded_state = dict(np.load(path, allow_pickle=False))
 
     def _make_static_embedding_repeated(
 

--- a/googlehydrology/utils/config.py
+++ b/googlehydrology/utils/config.py
@@ -129,6 +129,7 @@ class Config(object):
             new_name = re.sub(' ', '', new_name)
 
             self._cfg['experiment_name'] = new_name
+            
 
     def as_dict(self) -> dict:
         """Return run configuration as dictionary.
@@ -736,6 +737,10 @@ class Config(object):
     def seq_length(self) -> int | dict[str, int]:
         return self._get_value_verbose('seq_length')
 
+    @seq_length.setter
+    def seq_length(self, val: int | dict[str, int]) -> None:
+        self._cfg['seq_length'] = val
+
     @property
     def static_attributes(self) -> list[str]:
         return self._as_default_list(self._cfg['static_attributes'])
@@ -800,6 +805,23 @@ class Config(object):
     @train_dir.setter
     def train_dir(self, folder: Path):
         self._cfg['train_dir'] = folder
+
+    @property
+    def hot_start_path(self) -> Path | None:
+        val = self._cfg.get('hot_start_path', None)
+        return Path(val).expanduser() if val else None
+
+    @hot_start_path.setter
+    def hot_start_path(self, path: str | Path | None) -> None:
+        self._cfg['hot_start_path'] = Path(path).expanduser() if path else None
+
+    @property
+    def save_state(self) -> bool:
+        return bool(self._cfg.get('save_state', False))
+
+    @save_state.setter
+    def save_state(self, val: bool) -> None:
+        self._cfg['save_state'] = bool(val)
 
     @property
     def train_end_date(self) -> list[pd.Timestamp]:

--- a/test/test_hot_start.py
+++ b/test/test_hot_start.py
@@ -115,6 +115,7 @@ def test_handoff_forecast_lstm_hot_start(mock_check, mock_load, tmp_path):
     cfg.seq_length = 0
     cfg.hot_start_path = str(state_path)
     model.seq_length = 0
+    model.load_state_from_disk(state_path)
 
     hot_data = {}
     hot_data['x_d_hindcast'] = {
@@ -177,6 +178,7 @@ def test_mean_embedding_forecast_lstm_hot_start(mock_check, mock_load, tmp_path)
     cfg.seq_length = 0
     cfg.hot_start_path = str(state_path)
     model.seq_length = 0
+    model.load_state_from_disk(state_path)
 
     hot_data = {}
     hot_data['x_d_hindcast'] = {
@@ -267,5 +269,136 @@ def test_hot_start_batch_size_validation(tmp_path):
         ValueError, match='Hot-start inference requires batch_size=1'
     ):
         RegressionTester(cfg, run_dir=tmp_path, init_model=False)
+
+
+@patch('googlehydrology.datautils.scaler.Scaler.load')
+@patch('googlehydrology.datautils.scaler.Scaler.check_zero_scale')
+def test_multi_basin_state_isolation(mock_check, mock_load, tmp_path):
+    cfg_dict = get_base_cfg(tmp_path)
+    cfg = Config(cfg_dict, dev_mode=True)
+    model = HandoffForecastLSTM(cfg)
+
+    state_path = tmp_path / 'state_basin_a.npz'
+    dummy_data = {
+        'x_d_hindcast': {
+            'pr_day_gridmet': torch.rand(1, cfg.seq_length, 1),
+            'tmmn_day_gridmet': torch.rand(1, cfg.seq_length, 1),
+        },
+        'x_d_forecast': {
+            'pr_day_gridmet': torch.rand(
+                1, cfg.lead_time + cfg.forecast_overlap, 1
+            ),
+            'tmmn_day_gridmet': torch.rand(
+                1, cfg.lead_time + cfg.forecast_overlap, 1
+            ),
+        },
+        'x_s': torch.rand(1, len(cfg.static_attributes)),
+    }
+    model.save_state(dummy_data, state_path)
+
+    # Basin A: Loads state
+    model.load_state_from_disk(state_path)
+    assert model._preloaded_state is not None
+
+    # Basin B: Resets state between basins
+    model.reset_state()
+    assert model._preloaded_state is None
+
+
+@patch('googlehydrology.datautils.scaler.Scaler.load')
+@patch('googlehydrology.datautils.scaler.Scaler.check_zero_scale')
+def test_cold_start_output_shape(mock_check, mock_load, tmp_path):
+    cfg_dict = get_base_cfg(tmp_path)
+    cfg = Config(cfg_dict, dev_mode=True)
+    model = HandoffForecastLSTM(cfg)
+    model.eval()
+
+    device = next(model.parameters()).device
+    batch_size = 2
+    data = {
+        'x_d_hindcast': {
+            'pr_day_gridmet': torch.rand(
+                batch_size, cfg.seq_length, 1, device=device
+            ),
+            'tmmn_day_gridmet': torch.rand(
+                batch_size, cfg.seq_length, 1, device=device
+            ),
+        },
+        'x_d_forecast': {
+            'pr_day_gridmet': torch.rand(
+                batch_size,
+                cfg.lead_time + cfg.forecast_overlap,
+                1,
+                device=device,
+            ),
+            'tmmn_day_gridmet': torch.rand(
+                batch_size,
+                cfg.lead_time + cfg.forecast_overlap,
+                1,
+                device=device,
+            ),
+        },
+        'x_s': torch.rand(
+            batch_size, len(cfg.static_attributes), device=device
+        ),
+    }
+    with torch.no_grad():
+        cold_preds = model(data)
+
+    # In cold start, output must have length == seq_length
+    assert cold_preds['y_hat'].shape[1] == cfg.seq_length
+
+
+@patch('googlehydrology.datautils.scaler.Scaler.load')
+@patch('googlehydrology.datautils.scaler.Scaler.check_zero_scale')
+def test_forecast_overlap_variations(mock_check, mock_load, tmp_path):
+    # Test with forecast_overlap = 0
+    cfg_dict = get_base_cfg(tmp_path)
+    cfg_dict['forecast_overlap'] = 0
+    cfg = Config(cfg_dict, dev_mode=True)
+    model = HandoffForecastLSTM(cfg)
+    model.eval()
+
+    device = next(model.parameters()).device
+    batch_size = 2
+    data = {
+        'x_d_hindcast': {
+            'pr_day_gridmet': torch.rand(
+                batch_size, cfg.seq_length, 1, device=device
+            ),
+            'tmmn_day_gridmet': torch.rand(
+                batch_size, cfg.seq_length, 1, device=device
+            ),
+        },
+        'x_d_forecast': {
+            'pr_day_gridmet': torch.rand(
+                batch_size, cfg.lead_time, 1, device=device
+            ),
+            'tmmn_day_gridmet': torch.rand(
+                batch_size, cfg.lead_time, 1, device=device
+            ),
+        },
+        'x_s': torch.rand(
+            batch_size, len(cfg.static_attributes), device=device
+        ),
+    }
+    state_path = tmp_path / 'state_no_overlap.npz'
+    model.save_state(data, state_path)
+
+    cfg.seq_length = 0
+    cfg.hot_start_path = str(state_path)
+    model.seq_length = 0
+    model.load_state_from_disk(state_path)
+
+    hot_data = {
+        'x_d_hindcast': {
+            k: v[:, 0:0, :] for k, v in data['x_d_hindcast'].items()
+        },
+        'x_d_forecast': data['x_d_forecast'],
+        'x_s': data['x_s'],
+    }
+    with torch.no_grad():
+        hot_preds = model(hot_data)
+    assert hot_preds['y_hat'].shape[1] == cfg.lead_time
 
 

--- a/test/test_hot_start.py
+++ b/test/test_hot_start.py
@@ -1,0 +1,271 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+from googlehydrology.modelzoo.handoff_forecast_lstm import HandoffForecastLSTM
+from googlehydrology.modelzoo.mean_embedding_forecast_lstm import MeanEmbeddingForecastLSTM
+from googlehydrology.utils.config import Config
+
+
+def get_base_cfg(tmp_path: Path) -> dict:
+    basin_file = tmp_path / 'test_basin.txt'
+    with open(basin_file, 'w') as f:
+        f.write('us_03338780\n')
+
+    return {
+        'model': 'HandoffForecastLSTM',
+        'run_dir': str(tmp_path),
+        'experiment_name': 'test_hot_start',
+        'data_dir': str(tmp_path),
+        'test_basin_file': str(basin_file),
+        'train_basin_file': str(basin_file),
+        'validation_basin_file': str(basin_file),
+        'test_start_date': '01/01/2012',
+        'test_end_date': '05/01/2012',
+        'train_start_date': '01/01/2011',
+        'train_end_date': '31/12/2011',
+        'validation_start_date': '01/01/2011',
+        'validation_end_date': '31/12/2011',
+        'seq_length': 30,
+        'lead_time': 5,
+        'head': 'regression',
+        'target_variables': ['streamflow'],
+        'hindcast_inputs': ['pr_day_gridmet', 'tmmn_day_gridmet'],
+        'forecast_inputs': ['pr_day_gridmet', 'tmmn_day_gridmet'],
+        'static_attributes': ['area_gages2', 'elev_mean_x', 'p_mean_x'],
+        'hidden_size': 16,
+        'forecast_overlap': 2,
+        'state_handoff_network': {
+            'type': 'fc',
+            'hiddens': [16],
+            'activation': ['relu'],
+            'dropout': 0.0,
+        },
+        'hindcast_embedding': {
+            'type': 'fc',
+            'hiddens': [16],
+            'activation': ['relu'],
+            'dropout': 0.0,
+        },
+        'forecast_embedding': {
+            'type': 'fc',
+            'hiddens': [16],
+            'activation': ['relu'],
+            'dropout': 0.0,
+        },
+        'statics_embedding': {
+            'type': 'fc',
+            'hiddens': [16],
+            'activation': ['relu'],
+            'dropout': 0.0,
+        },
+        'lazy_load': False,
+        'batch_size': 2,
+        'epochs': 1,
+        'initial_learning_rate': 1e-3,
+        'loss': 'nse',
+        'optimizer': 'Adam',
+        'number_of_basins': 1,
+        'nan_handling_method': 'masked_mean',
+        'predict_last_n': 0,
+    }
+
+
+@patch('googlehydrology.datautils.scaler.Scaler.load')
+@patch('googlehydrology.datautils.scaler.Scaler.check_zero_scale')
+def test_handoff_forecast_lstm_hot_start(mock_check, mock_load, tmp_path):
+    cfg_dict = get_base_cfg(tmp_path)
+    cfg_dict['model'] = 'HandoffForecastLSTM'
+    cfg = Config(cfg_dict, dev_mode=True)
+    model = HandoffForecastLSTM(cfg)
+    model.eval()
+
+    device = next(model.parameters()).device
+    batch_size = 2
+    data = {}
+
+    data['x_d_hindcast'] = {
+        'pr_day_gridmet': torch.rand(
+            batch_size, cfg.seq_length, 1, device=device
+        ),
+        'tmmn_day_gridmet': torch.rand(
+            batch_size, cfg.seq_length, 1, device=device
+        ),
+    }
+    data['x_d_forecast'] = {
+        'pr_day_gridmet': torch.rand(
+            batch_size, cfg.lead_time + cfg.forecast_overlap, 1, device=device
+        ),
+        'tmmn_day_gridmet': torch.rand(
+            batch_size, cfg.lead_time + cfg.forecast_overlap, 1, device=device
+        ),
+    }
+    data['x_s'] = torch.rand(
+        batch_size, len(cfg.static_attributes), device=device
+    )
+
+    state_path = tmp_path / 'state_handoff.npz'
+    with torch.no_grad():
+        model.seq_length = cfg.seq_length
+        model.save_state(data, state_path)
+        cold_preds = model(data)
+
+    # Hot start run with seq_length=0
+    cfg.seq_length = 0
+    cfg.hot_start_path = str(state_path)
+    model.seq_length = 0
+
+    hot_data = {}
+    hot_data['x_d_hindcast'] = {
+        k: v[:, 0:0, :] for k, v in data['x_d_hindcast'].items()
+    }
+    hot_data['x_d_forecast'] = data['x_d_forecast']
+    hot_data['x_s'] = data['x_s']
+
+    with torch.no_grad():
+        hot_preds = model(hot_data)
+
+    cold_last = cold_preds['y_hat'][:, -cfg.lead_time :, :]
+    hot_last = hot_preds['y_hat'][:, -cfg.lead_time :, :]
+    assert (cold_last - hot_last).abs().max() < 1e-5
+
+
+@patch('googlehydrology.datautils.scaler.Scaler.load')
+@patch('googlehydrology.datautils.scaler.Scaler.check_zero_scale')
+def test_mean_embedding_forecast_lstm_hot_start(mock_check, mock_load, tmp_path):
+    cfg_dict = get_base_cfg(tmp_path)
+    cfg_dict['model'] = 'MeanEmbeddingForecastLSTM'
+    cfg_dict['n_distributions'] = 1
+    # For MeanEmbedding, forecast_overlap is typically sequence length.
+    cfg_dict['forecast_overlap'] = cfg_dict['seq_length']
+    cfg = Config(cfg_dict, dev_mode=True)
+    model = MeanEmbeddingForecastLSTM(cfg)
+    model.eval()
+
+    device = next(model.parameters()).device
+    batch_size = 2
+    data = {}
+
+    data['x_d_hindcast'] = {
+        'pr_day_gridmet': torch.rand(
+            batch_size, cfg.seq_length + cfg.lead_time, 1, device=device
+        ),
+        'tmmn_day_gridmet': torch.rand(
+            batch_size, cfg.seq_length + cfg.lead_time, 1, device=device
+        ),
+    }
+    data['x_d_forecast'] = {
+        'pr_day_gridmet': torch.rand(
+            batch_size, cfg.seq_length + cfg.lead_time, 1, device=device
+        ),
+        'tmmn_day_gridmet': torch.rand(
+            batch_size, cfg.seq_length + cfg.lead_time, 1, device=device
+        ),
+    }
+    data['x_s'] = torch.rand(
+        batch_size, len(cfg.static_attributes), device=device
+    )
+
+    state_path = tmp_path / 'state_mean.npz'
+    with torch.no_grad():
+        model.seq_length = cfg.seq_length
+        model.save_state(data, state_path)
+        cold_preds = model(data)
+
+    # Hot start run with seq_length=0
+    cfg.seq_length = 0
+    cfg.hot_start_path = str(state_path)
+    model.seq_length = 0
+
+    hot_data = {}
+    hot_data['x_d_hindcast'] = {
+        k: v[:, -(cfg.lead_time) :, :] for k, v in data['x_d_hindcast'].items()
+    }
+    hot_data['x_d_forecast'] = {
+        k: v[:, -(cfg.lead_time) :, :] for k, v in data['x_d_forecast'].items()
+    }
+    hot_data['x_s'] = data['x_s']
+
+    with torch.no_grad():
+        hot_preds = model(hot_data)
+
+    cold_last = cold_preds['y_hat'][:, -cfg.lead_time :, :]
+    hot_last = hot_preds['y_hat'][:, -cfg.lead_time :, :]
+    assert (cold_last - hot_last).abs().max() < 1e-5
+
+
+@patch('googlehydrology.datautils.scaler.Scaler.load')
+@patch('googlehydrology.datautils.scaler.Scaler.check_zero_scale')
+def test_hot_start_preloading(mock_check, mock_load, tmp_path):
+    cfg_dict = get_base_cfg(tmp_path)
+    cfg = Config(cfg_dict, dev_mode=True)
+    model = HandoffForecastLSTM(cfg)
+    model.eval()
+
+    device = next(model.parameters()).device
+    batch_size = 2
+    data = {
+        'x_d_hindcast': {
+            'pr_day_gridmet': torch.rand(
+                batch_size, cfg.seq_length, 1, device=device
+            ),
+            'tmmn_day_gridmet': torch.rand(
+                batch_size, cfg.seq_length, 1, device=device
+            ),
+        },
+        'x_d_forecast': {
+            'pr_day_gridmet': torch.rand(
+                batch_size,
+                cfg.lead_time + cfg.forecast_overlap,
+                1,
+                device=device,
+            ),
+            'tmmn_day_gridmet': torch.rand(
+                batch_size,
+                cfg.lead_time + cfg.forecast_overlap,
+                1,
+                device=device,
+            ),
+        },
+        'x_s': torch.rand(
+            batch_size, len(cfg.static_attributes), device=device
+        ),
+    }
+
+    state_path = tmp_path / 'state_preload.npz'
+    model.save_state(data, state_path)
+
+    # Test preloading into model
+    cfg.seq_length = 0
+    cfg.hot_start_path = str(state_path)
+    model.seq_length = 0
+    model.load_state_from_disk(state_path)
+
+    hot_data = {
+        'x_d_hindcast': {
+            k: v[:, 0:0, :] for k, v in data['x_d_hindcast'].items()
+        },
+        'x_d_forecast': data['x_d_forecast'],
+        'x_s': data['x_s'],
+    }
+    with torch.no_grad():
+        preds = model(hot_data)
+    assert preds['y_hat'].shape[1] == cfg.lead_time
+
+
+def test_hot_start_batch_size_validation(tmp_path):
+    import pytest
+    from googlehydrology.evaluation.tester import RegressionTester
+
+    cfg_dict = get_base_cfg(tmp_path)
+    cfg_dict['hot_start_path'] = str(tmp_path / 'dummy_state.npz')
+    cfg_dict['batch_size'] = 16
+    cfg = Config(cfg_dict, dev_mode=True)
+
+    with pytest.raises(
+        ValueError, match='Hot-start inference requires batch_size=1'
+    ):
+        RegressionTester(cfg, run_dir=tmp_path, init_model=False)
+
+


### PR DESCRIPTION
## Description
This PR introduces a "hot start" feature that allows users to save the final cell and hidden states of the hindcast LSTMs and subsequently resume inference initialized directly from those states. 
This skips the memory and computational overhead of re-simulating the entire `seq_length` hindcast spin-up period and removes the requirement to load the full historical timeseries datasets when generating day-of forecasts.
### Key Capabilities and Changes
- **No-Pickle State Persistence:** Model states are structurally exported and imported via Numpy's `np.savez_compressed` (avoiding standard `torch.save()` pickle wrappers) to guarantee cross-machine portability and security. Both hidden states (`h`) and cell states (`c`) are preserved for hindcast and forecast networks.
- **`HandoffForecastLSTM` Logic:** Rebuilt the sequence forward pass to conditionally bypass the `handoff_network` and overlap merging during hot start mode (`seq_length = 0`), directly initializing hidden and cell states for the `forecast_lstm`.
- **`MeanEmbeddingForecastLSTM` Logic:** Updated forward pass and embedding masking to accept initial state injections sequentially on hindcast and forecast LSTM blocks.
- **Evaluation Runner Integration (`tester.py`):**
  - **Per-Basin Pre-Loading:** Pre-loads state archives once per basin in `BaseTester._evaluate` from either a single file or a directory (`state_{basin}.npz` / `{basin}.npz`), eliminating per-step disk I/O.
  - **Automatic State Saving:** Automatically persists final states to `<run_dir>/hot_start_states/state_{basin}.npz` during evaluation when `save_state: True`.
  - **Batch Size Validation:** Enforces `batch_size = 1` for hot-start runs with descriptive error messaging.
- **Configuration Support (`config.py`):** Added `save_state`, `hot_start_path`, and `seq_length` properties and setters to `Config`.
- **Validation Fallbacks:** Added `seq_length <= 0` checks in `validate_samples.py` so multidimensional datasets process zero-sized historical sequences gracefully.
- **Hot Start Configuration Template:** Added `example-configs/template_hot_start_config.yml` as boilerplate for hot-start execution.
## Testing
- Added `test/test_hot_start.py` with 4 automated, self-contained unit tests using pytest's `tmp_path` fixture (fully compatible with GitHub Actions CI):
  1. `test_handoff_forecast_lstm_hot_start`: Verified cold vs. hot start numerical parity ($< 10^{-5}$ max absolute diff).
  2. `test_mean_embedding_forecast_lstm_hot_start`: Verified cold vs. hot start numerical parity ($< 10^{-5}$ max absolute diff).
  3. `test_hot_start_preloading`: Verified in-memory state restoration via `load_state_from_disk`.
  4. `test_hot_start_batch_size_validation`: Verified `batch_size != 1` validation in `RegressionTester`.
