### PR TITLE
Fix HandoffForecastLSTM feature ordering

### DIFF
--- a/googlehydrology/modelzoo/handoff_forecast_lstm.py
+++ b/googlehydrology/modelzoo/handoff_forecast_lstm.py
@@ -28,6 +28,13 @@ from googlehydrology.utils.lstm_utils import lstm_init
 FC_XAVIER = WeightInitOpt.FC_XAVIER
 
 
+def _concat_dynamic_features(
+    data: dict[str, torch.Tensor], feature_names: list[str]
+) -> torch.Tensor:
+    """Concatenate dynamic features in the model-defined feature order."""
+    return torch.cat([data[name] for name in feature_names], dim=-1)
+
+
 class HandoffForecastLSTM(BaseModel):
     """
     An encoder/decoder LSTM model class used for forecasting.
@@ -247,16 +254,12 @@ class HandoffForecastLSTM(BaseModel):
         """
 
         # Run the embedding layers.
-        hindcast_features = torch.cat(
-            [
-                t for f, t in data['x_d_hindcast'].items()
-                if f in self.hindcast_inputs
-            ], dim=-1)
-        forecast_features = torch.cat(
-            [
-                t for f, t in data['x_d_forecast'].items()
-                if f in self.forecast_inputs
-            ], dim=-1)
+        hindcast_features = _concat_dynamic_features(
+            data['x_d_hindcast'], self.hindcast_inputs
+        )
+        forecast_features = _concat_dynamic_features(
+            data['x_d_forecast'], self.forecast_inputs
+        )
 
         statics_embeddings = self.statics_embedding_net(data['x_s'])
         hindcast_embeddings = self.hindcast_embedding_net(hindcast_features)
@@ -454,13 +457,8 @@ class HandoffForecastLSTM(BaseModel):
             The file path where the state should be saved (.npz format).
         """
         # Run the embedding layers.
-        hindcast_features = torch.cat(
-            [
-                t
-                for f, t in data['x_d_hindcast'].items()
-                if f in self.hindcast_inputs
-            ],
-            dim=-1,
+        hindcast_features = _concat_dynamic_features(
+            data['x_d_hindcast'], self.hindcast_inputs
         )
 
         statics_embeddings = self.statics_embedding_net(data['x_s'])
@@ -477,13 +475,8 @@ class HandoffForecastLSTM(BaseModel):
         )
 
         # We run the exact same logic up to the final temporal state (Day D)
-        forecast_features = torch.cat(
-            [
-                t
-                for f, t in data['x_d_forecast'].items()
-                if f in self.forecast_inputs
-            ],
-            dim=-1,
+        forecast_features = _concat_dynamic_features(
+            data['x_d_forecast'], self.forecast_inputs
         )
 
         forecast_embeddings = self.forecast_embedding_net(forecast_features)

--- a/test/test_handoff_forecast_lstm.py
+++ b/test/test_handoff_forecast_lstm.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for HandoffForecastLSTM feature ordering."""
+
+import torch
+
+from googlehydrology.modelzoo.handoff_forecast_lstm import (
+    _concat_dynamic_features,
+)
+
+
+def test_concat_dynamic_features_uses_model_feature_order() -> None:
+    data = {
+        'temperature': torch.tensor([[[2.0], [4.0]]]),
+        'precipitation': torch.tensor([[[1.0], [3.0]]]),
+    }
+
+    result = _concat_dynamic_features(
+        data, ['precipitation', 'temperature']
+    )
+
+    expected = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+    assert torch.equal(result, expected)


### PR DESCRIPTION
Fixes #281.

Concatenates hindcast and forecast dynamic features in the model-defined feature order instead of dictionary insertion order, including the hot-start state-saving path. Adds a regression test with deliberately reversed dictionary insertion order.

Validation:
- targeted feature-order regression check
- Python syntax compilation
- git diff --check