### PR TITLE
Fix LSTM forget bias initialization

### DIFF
--- a/googlehydrology/utils/lstm_utils.py
+++ b/googlehydrology/utils/lstm_utils.py
@@ -35,11 +35,10 @@ def lstm_init(
     """Initialize LSTM weights."""
     with torch.no_grad():
         for lstm in lstms:
-            if forget_bias is not None:
-                lstm.bias_hh_l0.data[_forget_gate_slice(lstm)] = forget_bias
-
             for name, param in lstm.named_parameters():
-                if 'weight_ih' in name and LSTM_IH_XAVIER in weight_opts:
+                if forget_bias is not None and name.startswith('bias_hh_'):
+                    param.data[_forget_gate_slice(lstm)] = forget_bias
+                elif 'weight_ih' in name and LSTM_IH_XAVIER in weight_opts:
                     nn.init.xavier_uniform_(param)
                 elif 'weight_hh' in name and LSTM_HH_ORTHOGONAL in weight_opts:
                     nn.init.orthogonal_(param)

--- a/test/test_lstm_utils.py
+++ b/test/test_lstm_utils.py
@@ -31,7 +31,9 @@ def test_forget_gate_slice():
 
 @pytest.mark.unit
 def test_lstm_init():
-    lstm = nn.LSTM(input_size=10, hidden_size=20)
+    lstm = nn.LSTM(
+        input_size=10, hidden_size=20, num_layers=3, bidirectional=True
+    )
     lstm_init(
         lstms=[lstm],
         forget_bias=1.5,
@@ -40,6 +42,14 @@ def test_lstm_init():
             WeightInitOpt.LSTM_HH_ORTHOGONAL,
         ],
     )
-    # Check forget bias initialized
+    # Check forget bias initialized for every layer and direction.
     sl = _forget_gate_slice(lstm)
-    assert torch.allclose(lstm.bias_hh_l0.data[sl], torch.tensor(1.5))
+    for name, param in lstm.named_parameters():
+        if name.startswith('bias_hh_'):
+            assert torch.allclose(param.data[sl], torch.tensor(1.5))
+
+
+@pytest.mark.unit
+def test_lstm_init_without_bias():
+    lstm = nn.LSTM(input_size=10, hidden_size=20, bias=False)
+    lstm_init(lstms=[lstm], forget_bias=1.5)


### PR DESCRIPTION
Fixes #278.

Initialises the configured forget bias for every recurrent hidden-bias parameter instead of only `bias_hh_l0`. This covers multi-layer and bidirectional LSTMs, while `bias=False` now works naturally because no bias parameters are present.

Adds regression coverage for all layers/directions and for unbiased LSTMs.

Validation:
- `python -m pytest -q test/test_lstm_utils.py` (3 passed)
- `ruff check googlehydrology/utils/lstm_utils.py test/test_lstm_utils.py`
- Python syntax compilation
- `git diff --check`