### PR TITLE
Apply negative clipping to deterministic CMAL forecasts

### DIFF
--- a/googlehydrology/utils/samplingutils.py
+++ b/googlehydrology/utils/samplingutils.py
@@ -62,7 +62,9 @@ def sample_pointpredictions(
     if model.cfg.head.lower() == 'cmal':
         samples = sample_cmal(model, data, n_samples, scaler, outputs=outputs)
     elif model.cfg.head.lower() == 'cmal_deterministic':
-        samples = sample_cmal_deterministic(model, data, outputs=outputs)
+        samples = sample_cmal_deterministic(
+            model, data, scaler, outputs=outputs
+        )
     elif model.cfg.head.lower() == 'regression':  # regression head assumes mcd
         assert not outputs, 'regression self creates outputs'
         samples = sample_mcd(model, data, n_samples, scaler)
@@ -330,6 +332,7 @@ def sample_mcd(
 def sample_cmal_deterministic(
     model: 'BaseModel',
     data: dict[str, torch.Tensor],
+    scaler: Scaler,
     *,
     outputs: dict[str, torch.Tensor] | None = None,
 ) -> dict[str, torch.Tensor]:
@@ -344,6 +347,8 @@ def sample_cmal_deterministic(
         A model with a CMAL head.
     data : dict[str, torch.Tensor]
         Dictionary, containing input features as key-value pairs.
+    scaler : Scaler
+        Scaler of the run.
     outputs, optional
         Model forward result
 
@@ -364,6 +369,15 @@ def sample_cmal_deterministic(
     # not point predictions.
     pred = outputs or model(data)
 
+    normalized_zeros = None
+    if (setup.cfg.negative_sample_handling or '').lower() == 'clip':
+        normalized_zeros = _calc_normalized_zero_thresholds(
+            scaler=scaler,
+            targets=setup.cfg.target_variables,
+            device=next(model.parameters()).device,
+            dtype=next(model.parameters()).dtype,
+        )
+
     # Map output frequencies to final sample tensors:
     samples = {}
 
@@ -374,10 +388,15 @@ def sample_cmal_deterministic(
         tau = pred[f'tau{freq_suffix}']  # asymmetries
         pi = pred[f'pi{freq_suffix}']  # weights
 
-        sample_points = [
-            cmal_deterministic.generate_predictions(mu, b, tau, pi)
-        ]
-        samples[f'y_hat{freq_suffix}'] = torch.stack(sample_points, 2)
+        values = cmal_deterministic.generate_predictions(mu, b, tau, pi)
+        if normalized_zeros is not None:
+            values = _handle_negative_values(
+                setup.cfg,
+                values,
+                sample_values=lambda ids: values[ids],
+                normalized_zero=normalized_zeros[0],
+            )
+        samples[f'y_hat{freq_suffix}'] = torch.stack([values], 2)
 
     return samples
 
@@ -569,4 +588,3 @@ def sample_cmal(
         samples[f'y_hat{freq_suffix}'] = torch.stack(sample_points, dim=2)
 
     return samples
-

--- a/test/test_cmal_deterministic_clipping.py
+++ b/test/test_cmal_deterministic_clipping.py
@@ -1,0 +1,70 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+import xarray as xr
+
+from googlehydrology.utils import samplingutils
+
+
+@pytest.mark.unit
+def test_deterministic_cmal_clips_at_normalized_zero(monkeypatch):
+    model = MagicMock()
+    model.parameters.side_effect = lambda: iter([torch.zeros(1)])
+    model.cfg.head = 'cmal_deterministic'
+    model.cfg.mc_dropout = False
+    model.cfg.target_variables = ['streamflow']
+    model.cfg.use_frequencies = ['1D']
+    model.cfg.predict_last_n = {'1D': 2}
+    model.cfg.negative_sample_handling = 'clip'
+
+    scaler = MagicMock()
+    scaler.scaler = {
+        'streamflow': xr.DataArray(
+            [5.0, 2.0],
+            coords={'parameter': ['center', 'scale']},
+            dims=['parameter'],
+        )
+    }
+
+    generated = torch.tensor(
+        [[[-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+          [-4.0, -2.5, -1.5, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5]]]
+    )
+    monkeypatch.setattr(
+        samplingutils.cmal_deterministic,
+        'generate_predictions',
+        lambda *args: generated.clone(),
+    )
+
+    outputs = {
+        'mu': torch.zeros(1, 2, 3),
+        'b': torch.ones(1, 2, 3),
+        'tau': torch.full((1, 2, 3), 0.5),
+        'pi': torch.full((1, 2, 3), 1.0 / 3),
+    }
+    samples = samplingutils.sample_pointpredictions(
+        model,
+        {'y': torch.zeros(1, 2, 1)},
+        n_samples=10,
+        scaler=scaler,
+        outputs=outputs,
+    )
+
+    assert samples['y_hat'].shape == (1, 2, 1, 10)
+    assert samples['y_hat'].min().item() == -2.5
+    assert samples['y_hat'][0, 0, 0, 1].item() == -2.0

--- a/test/test_uncertainty.py
+++ b/test/test_uncertainty.py
@@ -50,7 +50,6 @@ def test_daily_uncertainty(
     ('none', 'clip', 'truncate') and with or without Monte Carlo dropout.
     """
 
-    # TODO (future) :: clip fails with CMAL-deterministic, should call _handle_negative_values
     config = get_config('forecast')
     updates = {
         'model': forecast_model,
@@ -134,10 +133,7 @@ def _check_uncertainty_output(
     negative_vals = test_vals[sample_key].values[
         test_vals[sample_key].values < 0
     ]
-    if (
-        negative_sample_handling == 'clip'
-        and config.head.lower() != 'cmal_deterministic'
-    ):
+    if negative_sample_handling == 'clip':
         # For 'clip', we expect all non-negative values
         min_val = np.min(negative_vals) if len(negative_vals) > 0 else 0.0
         assert np.allclose(negative_vals, 0.0, atol=1e-6), (


### PR DESCRIPTION
Fixes #277.

Passes the run scaler into deterministic CMAL sampling and applies normalized-zero clipping to deterministic summary outputs when negative_sample_handling is clip. Unsupported handling values now follow the shared negative-value handler and raise instead of being silently ignored; truncate remains a documented no-op because deterministic CMAL emits summary statistics rather than redrawable samples.

Breaking API note: scaler is now a required positional argument to sample_cmal_deterministic. The only in-tree caller has been updated, but direct external/notebook callers need to pass the run scaler.

The mixture mean is clipped as a physical floor. This is max(E[X], 0), not a distributional correction equivalent to E[max(X, 0)].

Adds focused regression coverage for clip, none, unset, truncate and unsupported handling modes, and removes the integration-test exemption for deterministic CMAL.

Validation:
- Python syntax compilation
- git diff --check
- hosted cross-platform PyTest CI will validate the updated head
